### PR TITLE
Metrics: Avoid calling metrics in case it is null

### DIFF
--- a/src/MediaPlayer/index.js
+++ b/src/MediaPlayer/index.js
@@ -105,7 +105,7 @@ export default class Mediaplayer extends Lightning.Component {
   _registerListeners() {
     events.forEach(event => {
       const handler = e => {
-        if (this._metrics[event] && typeof this._metrics[event] === 'function') {
+        if (this._metrics && this._metrics[event] && typeof this._metrics[event] === 'function') {
           this._metrics[event]({ currentTime: this.videoEl.currentTime })
         }
         this.fire(event, { videoElement: this.videoEl, event: e })


### PR DESCRIPTION
In cases where we are getting an external close, the metrics seem to be already set to null. This avoids calling metrics.