### PR TITLE
Fix: wpe-lightning-sdk upgrade folder problem

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -23,10 +23,23 @@ const process = require('process')
 const replaceInFile = require('replace-in-file')
 const yesno = require('yesno')
 
-const nodeModulesFolder = path.join(
+let nodeModulesFolder
+
+const lighningjsNodeModulesFolder = path.join(
   process.cwd(),
   process.cwd().indexOf('node_modules') > -1 ? '../..' : 'node_modules'
 )
+
+const wpelightningNodeModulesFolder = path.join(
+  process.cwd(),
+  process.cwd().indexOf('node_modules') > -1 ? '..' : 'node_modules'
+)
+
+if (process.cwd().includes('@lightningjs')) {
+  nodeModulesFolder = lighningjsNodeModulesFolder
+} else {
+  nodeModulesFolder = wpelightningNodeModulesFolder
+}
 
 // create support lib (remove it first if it exists)
 const supportFolder = path.join(process.cwd(), '/support')
@@ -86,7 +99,7 @@ if (
           allowEmptyPaths: true,
           files: process.env.INIT_CWD + '/src/**/*',
           // eslint-disable-next-line
-      from: /(?:[^\/]*?)\s+from\s+(["'])(wpe-lightning-sdk)(["']);?/gi,
+          from: /(?:[^\/]*?)\s+from\s+(["'])(wpe-lightning-sdk)(["']);?/gi,
           to: match => {
             return match.replace('wpe-lightning-sdk', '@lightningjs/sdk')
           },

--- a/src/Language/index.js
+++ b/src/Language/index.js
@@ -63,6 +63,10 @@ const setTranslations = obj => {
   translations = obj
 }
 
+const getLanguage = () => {
+  return language
+}
+
 const setLanguage = lng => {
   language = null
   dictionary = null
@@ -147,6 +151,10 @@ export default {
 
   set(language) {
     return setLanguage(language)
+  },
+
+  get() {
+    return getLanguage()
   },
 
   available() {


### PR DESCRIPTION
**Problem**:
Sometimes when you are upgrading from SDK 2.x to SDK 3.x the postinstall.js script that runs after the installation fails to copy the files into some directories because doesn't know if it's running at wpe-lightning-sdk or at @lightningjs/sdk directory and need to have the correct path.

**Solution**:
Use and if where generating the node_modules directory that choose if you are in one place or another by looking the proccess.cwd includes @lightningjs or wpe-lightning-sdk (well, if you are in @lightningjs you are not on wpe-lightning-sdk :)