### PR TITLE
Fix/postinstall script

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -42,6 +42,7 @@ shell.cp('-R', path.join(nodeModulesFolder, '@lightningjs/core/dist/*'), support
 // create support/polyfills and copy all required polyfills from node_modules
 const supportPolyfillsFolder = path.join(supportFolder, '/polyfills')
 !shell.test('-d', supportPolyfillsFolder) && shell.mkdir(supportPolyfillsFolder)
+
 shell.cp(
   '-R',
   path.join(nodeModulesFolder, '/url-polyfill/url-polyfill.js'),
@@ -58,66 +59,69 @@ shell.cp(
   path.join(supportPolyfillsFolder, '/fetch.js')
 )
 
-// npm 7.0.* doesn't contain INIT_CWD in process.env, causing the post install script to fail
-// added a (hopefully) temporary conditional for the existense of INIT_CWD
-// See: https://github.com/rdkcentral/Lightning-SDK/issues/134 and
-// https://github.com/npm/cli/issues/2033
-const init_cwd = 'INIT_CWD' in process.env
-if (init_cwd === false) {
-  console.log(
-    'Not able to run the entire postinstall script due to missing INIT_CWD in process.env'
-  )
-  console.log('See https://github.com/rdkcentral/Lightning-SDK/issues/134 for more details')
-  process.exit()
-}
+console.log('\x1b[32m')
+console.log('=============================================================================\n')
+console.log(
+  'The package name of the Lightning SDK has recently changed from "wpe-lightning-sdk"\nto "@lightningjs/sdk"'
+)
+console.log('Read more about it here: http://www.lightningjs.io/announcements/carbon-release')
+console.log('\n\nFrom now on you should import plugins from the Lightning SDK like this:')
+console.log("\n\nimport { Utils } from '@lightningjs/sdk'\n")
+console.log('=============================================================================')
 
-const packageJson = require(path.join(process.env.INIT_CWD, 'package.json'))
-
+// check if there is a mismatch in the installation of the SDK
 if (
-  packageJson &&
-  packageJson.dependencies &&
-  Object.keys(packageJson.dependencies).indexOf('wpe-lightning-sdk') > -1
+  process.env.npm_package_name.includes('@lightningjs/sdk') && // installing @lightningjs/sdk packagename
+  process.cwd().includes('wpe-lightning-sdk') // in wpe-lightning-sdk folder
 ) {
-  console.log('\x1b[32m')
+  console.log('\x1b[31m')
   console.log('=============================================================================\n')
   console.log(
-    'The package name of the Lightning SDK has changed from "wpe-lightning-sdk"\nto "@lightningjs/sdk"'
+    'It seems like you are installing the new version of the Lightning SDK under the old\npackage namespace.'
   )
-  console.log('\n\nFrom now on you should now import plugins from the Lightning SDK like this:')
-  console.log("\n\nimport { Utils } from '@lightningjs/sdk'\n")
+  console.log(
+    'This may possibly result in unexpected errors in the rest of the postinstall script.\n\n'
+  )
+  console.log(
+    'Unless this is intentional, we recommend that you manually run the following commands'
+  )
+  console.log('in the root of your project to properly install the latest Lightning-SDK:\n')
+  console.log('npm uninstall wpe-lightning-sdk')
+  console.log('npm install @lightningjs/sdk\n')
   console.log('=============================================================================')
-  console.log('\x1b[0m')
-
-  yesno({
-    question:
-      'Do you want us to automatically update the Lightning-SDK imports in your project files? (y/n)',
-    defaultValue: null,
-  })
-    .then(ok => {
-      ok &&
-        replaceInFile({
-          allowEmptyPaths: true,
-          files: process.env.INIT_CWD + '/src/**/*',
-          // eslint-disable-next-line
-      from: /(?:[^\/]*?)\s+from\s+(["'])(wpe-lightning-sdk)(["']);?/gi,
-          to: match => {
-            return match.replace('wpe-lightning-sdk', '@lightningjs/sdk')
-          },
-        })
-          .then(result => {
-            const changedFiles = result
-              .filter(item => item.hasChanged === true)
-              .map(item => '- ' + item.file.replace(process.env.INIT_CWD, ''))
-
-            if (changedFiles.length) {
-              console.log('\x1b[32m')
-              console.log('\n\nThe following files have been automatically updated for you:\n\n')
-              console.log('\x1b[0m')
-              console.log(changedFiles.join('\n'))
-              console.log('\n\n')
-            }
-          })
-          .catch(console.error)
-    })
-    .catch(console.error)
 }
+
+console.log('\x1b[0m')
+
+yesno({
+  question:
+    'Do you want us to automatically check for old Lightning-SDK imports and update them in your project files? (y/n)',
+  defaultValue: null,
+})
+  .then(ok => {
+    ok &&
+      replaceInFile({
+        allowEmptyPaths: true,
+        files: process.env.INIT_CWD + '/src/**/*',
+        // eslint-disable-next-line
+        from: /(?:[^\/]*?)\s+from\s+(["'])(wpe-lightning-sdk)(["']);?/gi,
+        to: match => {
+          return match.replace('wpe-lightning-sdk', '@lightningjs/sdk')
+        },
+      })
+        .then(result => {
+          const changedFiles = result
+            .filter(item => item.hasChanged === true)
+            .map(item => '- ' + item.file.replace(process.env.INIT_CWD, ''))
+
+          if (changedFiles.length) {
+            console.log('\x1b[32m')
+            console.log('\n\nThe following files have been automatically updated for you:\n\n')
+            console.log('\x1b[0m')
+            console.log(changedFiles.join('\n'))
+            console.log('\n\n')
+          }
+        })
+        .catch(console.error)
+  })
+  .catch(console.error)

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -30,18 +30,18 @@ const nodeModulesFolder = path.join(
 
 // create support lib
 const supportFolder = path.join(process.cwd(), '/support')
-shell.mkdir(supportFolder)
+!shell.test('-d', supportFolder) && shell.mkdir(supportFolder)
 
 // create support/lib and copy all required libraries from node_modules
 const supportLibFolder = path.join(supportFolder, '/lib')
-shell.mkdir(supportLibFolder)
+!shell.test('-d', supportLibFolder) && shell.mkdir(supportLibFolder)
 
 shell.cp('-R', path.join(nodeModulesFolder, '@lightningjs/core/devtools/*'), supportLibFolder)
 shell.cp('-R', path.join(nodeModulesFolder, '@lightningjs/core/dist/*'), supportLibFolder)
 
 // create support/polyfills and copy all required polyfills from node_modules
 const supportPolyfillsFolder = path.join(supportFolder, '/polyfills')
-shell.mkdir(supportPolyfillsFolder)
+!shell.test('-d', supportPolyfillsFolder) && shell.mkdir(supportPolyfillsFolder)
 shell.cp(
   '-R',
   path.join(nodeModulesFolder, '/url-polyfill/url-polyfill.js'),


### PR DESCRIPTION
The postinstall script can fail in some cases when you install straight from Github under the old packagename (see #140)

It seems rather complicated to tailor for all of these cases, with quite some room for error. So instead we're now showing a warning with manual instructions for so called 'mismatch' cases.

Also, the notice about the package name change (and the automatic fix for imports) is shown now on every install during this transition phase.