### PR TITLE
BD-900:Relicense Lightning-SDK to Metrological Apache

### DIFF
--- a/support/startApp.js
+++ b/support/startApp.js
@@ -12,7 +12,7 @@ var _this = undefined;
  * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
- * Copyright 2020 RDK Management
+ * Copyright 2020 Metrological
  *
  * Licensed under the Apache License, Version 2.0 (the License);
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Reason for change:Relicense Lightning-SDK to Metrological Apache
Test Procedure: Jenkin build should pass after License header changes for RDK for listed repos
BD-900:Relicense Lightning-SDK to Metrological Apache update
Risks: None