### PR TITLE
feat(media): loadstart, progress, rendition

### DIFF
--- a/docs/plugins/metrics.md
+++ b/docs/plugins/metrics.md
@@ -221,28 +221,39 @@ The `Metrics.user` namespace is used for tracking media events.
 
 The [VideoPlayer plugin](/plugins/videoplayer) automatically tracks and sends Metrcs for the following media related events:
 
+- LoadStart
 - Abort
 - CanPlay
 - Ended
 - Pause
 - Play
+- Progress
 - Suspend
 - VolumeChange
 - Waiting
 - Seeking
 - Seeked
 - Ratechange
+- Rendition
 
 For apps that don't use the VideoPlayer plugin, tracking has to be implemented manually. Media metrics are initiated by
-calling the method `Metrics.media()` and passing it the url of the media asset that is being tracked.
+calling the method `Metrics.media()` and passing it the uri of the media asset that is being tracked. The uri may be a qualified URL to the CDN, or a unique identifier from a CMS.
 
 ```js
-const mediaMetrics = Metrics.media(assetUrl)
+const mediaMetrics = Metrics.media(assetUri)
 ```
 
 Next the following methods will become available on the `mediaMetrics` variable:
 
+#### Load Start
+Called when playback is requested, but before the frames are available.
+
+```js
+mediaMetrics.loadstart({ currentTime: ... })
+```
+
 #### Abort
+Playback was aborted, but not due to an error.
 
 ```js
 mediaMetrics.abort({ currentTime: ... })
@@ -255,23 +266,32 @@ mediaMetrics.canplay({ currentTime: ... })
 ```
 
 #### Ended
+Playback has stopped because the end of the media was reached.
 
 ```js
 mediaMetrics.canplay({ currentTime: ... })
 ```
 
 #### Pause
+Playback has been paused.
 
 ```js
 mediaMetrics.pause({ currentTime: ... })
 ```
 
 #### Play
+Playback has started either initially, or after being paused.
 
 ```js
 mediaMetrics.play({ currentTime: ... })
 ```
 
+#### Progress
+Called at regular intervals to update the current progress of playback.
+
+```js
+mediaMetrics.progress({ currentTime: ... })
+```
 
 #### Suspend
 
@@ -279,35 +299,46 @@ mediaMetrics.play({ currentTime: ... })
 mediaMetrics.suspend({ currentTime: ... })
 ```
 
-
 #### Volume Change
+Either the volume or the mute state has changed.
 
 ```js
 mediaMetrics.volumechange({ currentTime: ... })
 ```
 
 #### Waiting
+Playback has stopped because the next frame is not available, but will continue once it is available.
 
 ```js
 mediaMetrics.waiting({ currentTime: ... })
 ```
 
 #### Seeking
+Seeking was initiated.
 
 ```js
 mediaMetrics.seeking({ currentTime: ... })
 ```
 
 #### Seeked
+Seeking has completed.
 
 ```js
 mediaMetrics.seeked({ currentTime: ... })
 ```
 
 #### Ratechange
+The playback rate has changed.
 
 ```js
 mediaMetrics.ratechange({ currentTime: ... })
+```
+
+#### Rendition
+The playback rendition, e.g. bitrate, dimensions, etc., has changed.
+
+```js
+mediaMetrics.rendition({ currentTime: ..., bitrate: ..., width: ..., height: ... })
 ```
 
 <!-- ### Generic Error

--- a/docs/plugins/metrics.md
+++ b/docs/plugins/metrics.md
@@ -338,7 +338,7 @@ mediaMetrics.ratechange({ currentTime: ... })
 The playback rendition, e.g. bitrate, dimensions, etc., has changed.
 
 ```js
-mediaMetrics.rendition({ currentTime: ..., bitrate: ..., width: ..., height: ... })
+mediaMetrics.renditionchange({ currentTime: ..., bitrate: ..., width: ..., height: ... })
 ```
 
 <!-- ### Generic Error

--- a/src/Metrics/index.js
+++ b/src/Metrics/index.js
@@ -33,11 +33,13 @@ const metrics = {
   page: ['view', 'leave'],
   user: ['click', 'input'],
   media: [
+    'loadstart',
     'abort',
     'canplay',
     'ended',
     'pause',
     'play',
+    'progress',
     // with some videos there occur almost constant suspend events ... should investigate
     // 'suspend',
     'volumechange',
@@ -45,6 +47,7 @@ const metrics = {
     'seeking',
     'seeked',
     'ratechange',
+    'rendition'
   ],
 }
 

--- a/src/Metrics/index.js
+++ b/src/Metrics/index.js
@@ -47,7 +47,7 @@ const metrics = {
     'seeking',
     'seeked',
     'ratechange',
-    'rendition'
+    'renditionchange'
   ],
 }
 


### PR DESCRIPTION
# Justification

Time-to-first-frame (TTF) and unexpected video stops are two of the biggest quality concerns of a video platform, and can lead to audience drop-off. Video quality is a close third, since users will not stick around for low bitrate video with distracting artifacts due to encode quality.

Our metrics API should make it easy to provide analytics on:

- how long it takes video to start up (TTFF)
- how often (and for how long) video is interrupted unexpectedly
- what bitrates end user are viewing over time

https://medium.com/pinterest-engineering/optimizing-video-playback-performance-caf55ce310d1

## Changes

- `Metrics.media.loadstart` - used in conjunction with `play` to calculate TTFF
- `Metrics.media.progress` - used to keep track of how far end users watch video (to see if other QoS improvements are working)
- `Metrics.media.rendition` - used to keep track of currently playing rendition, e.g. bitrate & dimensions
- Documentation of various Media events (based on HTML5 video events)