### PR TITLE
feat(lifecycle): added ready method, tweaked tense

### DIFF
--- a/src/Lifecycle/index.js
+++ b/src/Lifecycle/index.js
@@ -23,8 +23,8 @@ import isProbablyLightningComponent from '../helpers/isProbablyLightningComponen
 import { initBaseEvents } from './base'
 import { initLightningEvents } from './lightning'
 
-const supportedStates = ['init', 'active', 'pause', 'background', 'close']
-let currentState = 'init'
+const supportedStates = ['loading', 'active', 'paused', 'background', 'closed']
+let currentState = supportedStates[0]
 
 export const initLifecycle = (app, transport) => {
   if (transport) {
@@ -51,6 +51,7 @@ const stateChange = (state) => {
 
 // public API
 export default {
+  ready() { stateChange('background') },
   close() { stateChange('close') }, // when the app wants to close
   state() { return currentState },
   addEventListener,

--- a/src/Lifecycle/index.js
+++ b/src/Lifecycle/index.js
@@ -23,7 +23,7 @@ import isProbablyLightningComponent from '../helpers/isProbablyLightningComponen
 import { initBaseEvents } from './base'
 import { initLightningEvents } from './lightning'
 
-const supportedStates = ['loading', 'active', 'paused', 'background', 'closed']
+const supportedStates = ['loading', 'active', 'paused', 'background', 'close']
 let currentState = supportedStates[0]
 
 export const initLifecycle = (app, transport) => {
@@ -51,7 +51,7 @@ const stateChange = (state) => {
 
 // public API
 export default {
-  ready() { stateChange('background') },
+  ready() { stateChange('active') },
   close() { stateChange('close') }, // when the app wants to close
   state() { return currentState },
   addEventListener,


### PR DESCRIPTION
## Overview
Firebolt has a few use cases that require two-way communication around starting up an app.

As a platform owner, I want to show a loading screen, e.g. branding for the app, while the app is loading, and unable to show anything on it's own. I want to hide this loading screen once the app is "ready."

As a platform owner, I want to load some apps in the background to facilitate fast app launching, e.g. apps that are used frequently. I need a way for the app to let me know once it's minimally loaded, so I know when activating it will be a good experience for the user.
  
## Justification
Fast app launching is a high priority, but high resource feature. The platform needs a way to decide when it will be leveraged in order to best manage it's resources. Apps need to be prepared to be hot-launched (e.g. activated after previously being loaded into the background) or cold-launched (e.g. full load & activate all at once).

## Changes
- added `ready()` callback, that apps must call in order to be activated
- set initial state to "loading", once app calls `ready()`, platform can now decide whether to immediately activate the app, or put it in the background, pending a hot-launch later
- tweaked tense of 'paused' and 'closed'