### PR TITLE
Soft exit vs hard exit

### DIFF
--- a/src/Advertising/index.js
+++ b/src/Advertising/index.js
@@ -8,11 +8,8 @@ export default {
   policy() {
     return Platform.get('advertising.policy')
   },
-  advertisingId(reset = false) {
-    return reset
-      ? Platform.get('advertising.advertisingId')
-      : // 'set null' means 'recreate new id'
-        Platform.set('advertising.advertisingId', null)
+  advertisingId() {
+    return Platform.get('advertising.advertisingId')
   },
   deviceAttributes() {
     return Platform.get('advertising.deviceAttributes')

--- a/src/Discovery/index.js
+++ b/src/Discovery/index.js
@@ -35,7 +35,7 @@ let watchNext = function(title, linkUrl, expires, contentId, images) {
   return Promise.resolve(true)
 }
 
-export const initAdvertising = config => {
+export const initDiscovery = config => {
   entitlements = config.entitlements
   watched = config.watched
   watchNext = config.watchNext

--- a/src/Lifecycle/index.js
+++ b/src/Lifecycle/index.js
@@ -68,8 +68,11 @@ export const initLifecycle = config => {
 
 // public API
 export default {
-  close() {
-    store.current = 'close'
+  exit(unload = false) {
+    if (unload)
+      store.current = 'closed'
+    else
+      store.current = 'paused'
   },
   ready() {
     store.current = 'ready'


### PR DESCRIPTION
## Overview
The Lifecycle API needs a way for applications to do both soft exits and hard exits.

A soft exit moves the app to the `background` state, and returns the user to the home screen.

A hard exit moves the app through the `closing`, and `closed` states.
  
## Justification
This is to enable two use cases:

- As an app developer, I want my application to go in the `paused` state when the user hits _back_ on their remote, in case the user decides to come back quickly, or left the app accidentally.

- As an app developer, I want my application to go into the `closing` and then `closed` states when the user manually selects an "Exit" option from the menu, so that when they return the app is reloaded to the home screen.

## Changes
- Propose we rename `close()` to `exit()`
- Add an optional `unload` (boolean) parameter to exit
