### PR TITLE
adding progress & completed back into parameters for watched

### DIFF
--- a/docs/plugins/discovery.md
+++ b/docs/plugins/discovery.md
@@ -42,13 +42,26 @@ Discovery.entitlements([
 ### Watched
 Adds a content the user's watch history to enable platform home screen awareness.
 
-Takes an array of watched items:
+Takes details on what was watched:
+
+```json
+Discovery.watched(contentId, watchedOn, progress, completed)
+```
+
+`contentId` - the content identifier of what was watched
+`watchedOn` - the date/time the user watched
+`progress` - the most recent percentile position (> 0, <= 1) the user reached while watching
+`completed` - whether or not the app considers this content fully watched, e.g. the credits have been reached
+
+or an array of the same details, for a bulk update:
 
 ```json
 Discovery.watched([
   {
     "contentId": "http://content/some/canonical/id",
-    "watchedOn": "2022-04-23T18:25:43.511Z"
+    "watchedOn": "2022-04-23T18:25:43.511Z",
+    "progress": 0.5,
+    "completed": false
   }
 ])
 ```


### PR DESCRIPTION
## Overview
Apps need a way to tell the platform what the resume point should be for a piece of content
  
## Justification
Platform home screen will want to show progress bars on thumbnails for resume watching lists

## Changes
- added progress & completed parameters to `watched`
- updated `watched` to support both bulk updates via an array, as well as single asset updates w/out an array