### PR TITLE
feat(FTL): Created Firebolt Transport Layer API

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
  * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
- * Copyright 2020 RDK Management
+ * Copyright 2021 Metrological
  *
  * Licensed under the Apache License, Version 2.0 (the License);
  * you may not use this file except in compliance with the License.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3812,7 +3812,7 @@
       }
     },
     "localCookie": {
-      "version": "github:WebPlatformForEmbedded/localCookie#fd9b6f12f6d467d071e6812e4b5ce2c6d2e01664",
+      "version": "github:WebPlatformForEmbedded/localCookie#4bd82a7f98954c44d5ef818a027b36591fab05f4",
       "from": "github:WebPlatformForEmbedded/localCookie"
     },
     "locate-path": {

--- a/src/Advertising/defaults.js
+++ b/src/Advertising/defaults.js
@@ -17,22 +17,16 @@
  * limitations under the License.
  */
 
-import Transport from '../Transport'
-
 export default {
-  config() {
-    return Transport.send('advertising', 'config')
+  config: {
+    siteSection: '96746720',
+    profile: '47883199',
   },
-  policy() {
-    return Transport.send('advertising', 'policy')
+  policy: {
+    adSkipTier: 'NOSKIP_NORMAL_SPEED',
+    adSkipGracePeriodSeconds: 60,
   },
-  advertisingId() {
-    return Transport.send('advertising', 'advertisingId')
-  },
-  deviceAttributes() {
-    return Transport.send('advertising', 'deviceAttributes')
-  },
-  appStoreId() {
-    return Transport.send('advertising', 'appStoreId')
-  },
+  advertisingId: 'oxPUKaCAtlyfy5ieomFw',
+  deviceAttributes: {},
+  appStoreId: '...',
 }

--- a/src/Authentication/defaults.js
+++ b/src/Authentication/defaults.js
@@ -17,22 +17,11 @@
  * limitations under the License.
  */
 
-import Transport from '../Transport'
-
 export default {
-  config() {
-    return Transport.send('advertising', 'config')
-  },
-  policy() {
-    return Transport.send('advertising', 'policy')
-  },
-  advertisingId() {
-    return Transport.send('advertising', 'advertisingId')
-  },
-  deviceAttributes() {
-    return Transport.send('advertising', 'deviceAttributes')
-  },
-  appStoreId() {
-    return Transport.send('advertising', 'appStoreId')
+  token: {
+    value:
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+    expires: '2022-04-23T18:25:43.511Z',
+    type: 'Example',
   },
 }

--- a/src/Authentication/index.js
+++ b/src/Authentication/index.js
@@ -1,3 +1,22 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2021 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import Transport from '../Transport'
 
 export default {

--- a/src/Authentication/index.js
+++ b/src/Authentication/index.js
@@ -1,18 +1,7 @@
-let getToken = function() {
-  return Promise.resolve({
-    value:
-      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
-    expires: '2022-04-23T18:25:43.511Z',
-    type: 'Example',
-  })
-}
-
-export const initAuthentication = config => {
-  getToken = config.getToken
-}
+import Transport from '../Transport'
 
 export default {
   token() {
-    return getToken()
+    return Transport.send('authentication', 'token')
   },
 }

--- a/src/Discovery/defaults.js
+++ b/src/Discovery/defaults.js
@@ -1,0 +1,60 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2021 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Log from '../Log'
+
+export let events = {
+  navigateTo: {
+    action: 'entity',
+    data: {
+      entityId: 'abc',
+    },
+    context: {
+      source: 'voice',
+    },
+  },
+}
+
+export default {
+  watched: function(params) {
+    let watchedItems = params.watchedItems
+    if (watchedItems && watchedItems.isArray && watchedItems.isArray())
+      watchedItems.reduce((items, item) => {
+        Log.info('Discovery', 'Added ' + item.watchedOn + ': ' + item.contentId)
+      })
+    else if (typeof watchedItems === 'object')
+      Log.info('Discovery', 'Added ' + watchedItems.watchedOn + ': ' + watchedItems.contentId)
+
+    return true
+  },
+  watchNext: function(params) {
+    let title = params.title
+    let linkUrl = params.linkUrl
+    let expires = params.expires
+    let contentId = params.contentId
+    let images = params.images
+    Log.info('Discovery', 'Added to Dashboard: ' + title + ', ' + linkUrl)
+    return true
+  },
+  entitlements: function(params) {
+    let entitlments = params.entitlements
+    Log.info('Discovery', 'Synchronized user entitlements')
+    return true
+  },
+}

--- a/src/Discovery/index.js
+++ b/src/Discovery/index.js
@@ -17,32 +17,24 @@
  * limitations under the License.
  */
 
-import Log from '../Log'
+import Transport from '../Transport'
 
-let entitlements = function(items) {
-  return Promise.resolve(true)
+let entitlements = function(entitlements) {
+  return Transport.send('discovery', 'entitlements', { entitlements: entitlements })
 }
 
 let watched = function(watchedItems) {
-  if (watchedItems && watchedItems.isArray && watchedItems.isArray())
-    watchedItems.reduce((items, item) => {
-      Log.info('Added ' + item.watchedOn + ': ' + item.contentId)
-    })
-  else if (typeof watchedItems === 'object')
-    Log.info('Added ' + watchedItems.watchedOn + ': ' + watchedItems.contentId)
-
-  return Promise.resolve(true)
+  return Transport.send('discovery', 'watched', { watchedItems: watchedItems })
 }
 
 let watchNext = function(title, linkUrl, expires, contentId, images) {
-  Log.info('Added to Dashboard: ' + title + ', ' + linkUrl)
-  return Promise.resolve(true)
-}
-
-export const initDiscovery = config => {
-  entitlements = config.entitlements
-  watched = config.watched
-  watchNext = config.watchNext
+  return Transport.send('discovery', 'watchNext', {
+    title: title,
+    linkUrl: linkUrl,
+    expires: expires,
+    contentId: contentId,
+    images: images,
+  })
 }
 
 export default {

--- a/src/Discovery/index.js
+++ b/src/Discovery/index.js
@@ -2,7 +2,7 @@
  * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
- * Copyright 2020 RDK Management
+ * Copyright 2021 Metrological
  *
  * Licensed under the Apache License, Version 2.0 (the License);
  * you may not use this file except in compliance with the License.

--- a/src/Lifecycle/defaults.js
+++ b/src/Lifecycle/defaults.js
@@ -17,22 +17,29 @@
  * limitations under the License.
  */
 
-import Transport from '../Transport'
+import { store } from './index'
+
+let finished = function() {
+  if (store.current === 'unloading') {
+    location.href = 'about:blank'
+  }
+}
 
 export default {
-  config() {
-    return Transport.send('advertising', 'config')
+  ready: function() {
+    store.current = 'inactive'
+    setTimeout(() => (store.current = 'foreground'), 100)
   },
-  policy() {
-    return Transport.send('advertising', 'policy')
+  close: function(params) {
+    let reason = params.reason
+    if (reason === 'REMOTE_BUTTON') {
+      store.current = 'inactive'
+      setTimeout(() => (store.current = 'foreground'), 2000)
+    } else {
+      store.current = 'inactive'
+      setTimeout(() => (store.current = 'unloading'), 500)
+      setTimeout(() => finished(), 2500)
+    }
   },
-  advertisingId() {
-    return Transport.send('advertising', 'advertisingId')
-  },
-  deviceAttributes() {
-    return Transport.send('advertising', 'deviceAttributes')
-  },
-  appStoreId() {
-    return Transport.send('advertising', 'appStoreId')
-  },
+  finished: finished,
 }

--- a/src/Lifecycle/index.js
+++ b/src/Lifecycle/index.js
@@ -2,7 +2,7 @@
  * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
- * Copyright 2020 RDK Management
+ * Copyright 2021 Metrological
  *
  * Licensed under the Apache License, Version 2.0 (the License);
  * you may not use this file except in compliance with the License.

--- a/src/Metrics/defaults.js
+++ b/src/Metrics/defaults.js
@@ -17,22 +17,14 @@
  * limitations under the License.
  */
 
-import Transport from '../Transport'
+import Log from '../Log'
 
 export default {
-  config() {
-    return Transport.send('advertising', 'config')
-  },
-  policy() {
-    return Transport.send('advertising', 'policy')
-  },
-  advertisingId() {
-    return Transport.send('advertising', 'advertisingId')
-  },
-  deviceAttributes() {
-    return Transport.send('advertising', 'deviceAttributes')
-  },
-  appStoreId() {
-    return Transport.send('advertising', 'appStoreId')
+  sendMetric: function(params) {
+    let type = params.type
+    let event = params.event
+    params = params.params
+
+    Log.info('Sending metric', type, event, params)
   },
 }

--- a/src/Metrics/index.js
+++ b/src/Metrics/index.js
@@ -2,7 +2,7 @@
  * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
- * Copyright 2020 RDK Management
+ * Copyright 2021 Metrological
  *
  * Licensed under the Apache License, Version 2.0 (the License);
  * you may not use this file except in compliance with the License.

--- a/src/Metrics/index.js
+++ b/src/Metrics/index.js
@@ -17,15 +17,7 @@
  * limitations under the License.
  */
 
-import Log from '../Log'
-
-let sendMetric = (type, event, params) => {
-  Log.info('Sending metric', type, event, params)
-}
-
-export const initMetrics = config => {
-  sendMetric = config.sendMetric
-}
+import Transport from '../Transport'
 
 // available metric per category
 const metrics = {
@@ -51,10 +43,14 @@ const metrics = {
   ],
 }
 
+const sendMetric = (type, event, params = {}) => {
+  Transport.send('metrics', 'sendMetric', { type: type, event: event, params: params })
+}
+
 // error metric function (added to each category)
 const errorMetric = (type, message, code, visible, params = {}) => {
   params = { params, ...{ message, code, visible } }
-  sendMetric(type, 'error', params)
+  Transport.send('metrics', 'sendMetric', { type: type, event: 'error', params: params })
 }
 
 const Metric = (type, events, options = {}) => {

--- a/src/Platform/defaults.js
+++ b/src/Platform/defaults.js
@@ -19,7 +19,7 @@
 
 import { getLocale, getLanguage, getCountryCode, getLatLon } from './helpers'
 
-export const defaultPlatform = {
+export default {
   localization: {
     city: 'New York',
     zipCode: '27505',
@@ -41,20 +41,28 @@ export const defaultPlatform = {
     uid: 'ee6723b8-7ab3-462c-8d93-dbf61227998e',
     type: 'STB',
     model: 'Metrological',
-    version: {
-      sdk: {
-        major: 0,
-        minor: 1,
-        patch: 0,
-        readable: 'Firebolt JS SDK v0.1.0',
-      },
-      os: {
-        major: 0,
-        minor: 1,
-        patch: 0,
-        readable: 'Firebolt OS v0.1.0',
-      },
-      debug: '',
+    version: function() {
+      let ver = {
+        sdk: {
+          major: 0,
+          minor: 1,
+          patch: 0,
+          readable: 'Firebolt JS SDK v0.1.0',
+        },
+        os: {
+          major: 0,
+          minor: 1,
+          patch: 0,
+          readable: 'Firebolt OS v0.1.0',
+        },
+        debug: '',
+      }
+      ver.debug = 'Operator - Platform\n'
+      ver.debug += new Date().toISOString() + '\n'
+      ver.debug += ver.sdk.readable + '\n'
+      ver.debug += ver.os.readable + '\n'
+      ver.debug += 'Example Component - v1.0.0'
+      return ver
     },
     hdcp: { 'hdcp1.4': true, 'hdcp2.2': false },
     hdr: {
@@ -97,18 +105,5 @@ export const defaultPlatform = {
       enabled: true,
       speed: 5,
     },
-  },
-  advertising: {
-    config: {
-      siteSection: '96746720',
-      profile: '47883199',
-    },
-    policy: {
-      adSkipTier: 'NOSKIP_NORMAL_SPEED',
-      adSkipGracePeriodSeconds: 60,
-    },
-    advertisingId: 'oxPUKaCAtlyfy5ieomFw',
-    deviceAttributes: {},
-    appStoreId: '...',
   },
 }

--- a/src/Platform/index.js
+++ b/src/Platform/index.js
@@ -16,175 +16,94 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Deepmerge from 'deepmerge'
-
-import Settings from '../Settings'
-import { defaultPlatform } from './defaults'
-
-let platform = {}
-
-let getProperty = (namespace, key) => {
-  namespace = namespace.toLowerCase()
-  platform = Deepmerge(defaultPlatform, Settings.get('platform', 'platform', {}), platform)
-
-  return new Promise((resolve, reject) => {
-    if (platform[namespace] && key in platform[namespace]) {
-      resolve(
-        typeof platform[namespace][key] === 'function'
-          ? platform[namespace][key]()
-          : platform[namespace][key]
-      )
-    } else {
-      reject(namespace + '.' + key + ' not found')
-    }
-  })
-}
-
-let setProperty = (namespace, key, params) => {
-  namespace = namespace.toLowerCase()
-
-  platform = Deepmerge(defaultPlatform, Settings.get('platform', 'platform', {}), platform)
-  return new Promise((resolve, reject) => {
-    if (platform[namespace] && key in platform[namespace]) {
-      platform[namespace][key] = params
-      resolve(params)
-    } else {
-      reject(namespace + '.' + key + ' not found')
-    }
-  })
-}
-
-let hasProperty = (namespace, key) => {
-  platform = Deepmerge(defaultPlatform, Settings.get('platform', 'platform', {}), platform)
-  return Promise.resolve(platform[namespace] && key in platform[namespace])
-}
-
-function getVersion() {
-  let ver = platform['device']['version']
-  console.log(ver)
-  ver.debug = 'Operator - Platform\n'
-  ver.debug += new Date().toISOString() + '\n'
-  ver.debug += ver.sdk.readable + '\n'
-  ver.debug += ver.os.readable + '\n'
-  ver.debug += 'Example Component - v1.0.0'
-  return Promise.resolve(ver)
-}
-
-export const initPlatform = config => {
-  getProperty = config.getProperty
-  setProperty = config.setProperty
-  hasProperty = config.hasProperty
-}
-
-const getOrSet = (namespace, key, params) =>
-  typeof params !== 'undefined' ? setProperty(namespace, key, params) : getProperty(namespace, key)
+import Transport from '../Transport'
 
 // public API
 export default {
   Localization: {
     city(params) {
-      return getOrSet('localization', 'city', params)
+      return Transport.send('platform.localization', 'city', params)
     },
     zipCode(params) {
-      return getOrSet('localization', 'zipCode', params)
+      return Transport.send('platform.localization', 'zipCode', params)
     },
     countryCode(params) {
-      return getOrSet('localization', 'countryCode', params)
+      return Transport.send('platform.localization', 'countryCode', params)
     },
     language(params) {
-      return getOrSet('localization', 'language', params)
+      return Transport.send('platform.localization', 'language', params)
     },
     latlon(params) {
-      return getOrSet('localization', 'latlon', params)
+      return Transport.send('platform.localization', 'latlon', params)
     },
     locale(params) {
-      return getOrSet('localization', 'locale', params)
+      return Transport.send('platform.localization', 'locale', params)
     },
   },
   Profile: {
     ageRating(params) {
-      return getOrSet('profile', 'ageRating', params)
+      return Transport.send('platform.profile', 'ageRating', params)
     },
   },
   Device: {
     ip(params) {
-      return getOrSet('device', 'ip', params)
+      return Transport.send('platform.device', 'ip', params)
     },
     household(params) {
-      return getOrSet('device', 'household', params)
+      return Transport.send('platform.device', 'household', params)
     },
     mac(params) {
-      return getOrSet('device', 'mac', params)
+      return Transport.send('platform.device', 'mac', params)
     },
     operator(params) {
-      return getOrSet('device', 'operator', params)
+      return Transport.send('platform.device', 'operator', params)
     },
     platform(params) {
-      return getOrSet('device', 'platform', params)
+      return Transport.send('platform.device', 'platform', params)
     },
     packages(params) {
-      return getOrSet('device', 'packages', params)
+      return Transport.send('platform.device', 'packages', params)
     },
     uid(params) {
-      return getOrSet('device', 'uid', params)
+      return Transport.send('platform.device', 'uid', params)
     },
     type(params) {
-      return getOrSet('device', 'type', params)
+      return Transport.send('platform.device', 'type', params)
     },
     model(params) {
-      return getOrSet('device', 'model', params)
+      return Transport.send('platform.device', 'model', params)
     },
     version() {
-      return getVersion()
+      return Transport.send('platform.device', 'version')
     },
     hdcp(params) {
-      return getOrSet('device', 'hdcp', params)
+      return Transport.send('platform.device', 'hdcp', params)
     },
     hdr(params) {
-      return getOrSet('device', 'hdr', params)
+      return Transport.send('platform.device', 'hdr', params)
     },
     audio(params) {
-      return getOrSet('device', 'audio', params)
+      return Transport.send('platform.device', 'audio', params)
     },
     screenResolution(params) {
-      return getOrSet('device', 'screenResolution', params)
+      return Transport.send('platform.device', 'screenResolution', params)
     },
     videoResolution(params) {
-      return getOrSet('device', 'videoResolution', params)
+      return Transport.send('platform.device', 'videoResolution', params)
     },
     name(params) {
-      return getOrSet('device', 'name', params)
+      return Transport.send('platform.device', 'name', params)
     },
     network(params) {
-      return getOrSet('device', 'network', params)
+      return Transport.send('platform.device', 'network', params)
     },
   },
   Accessibility: {
     closedCaptions(params) {
-      return getOrSet('accessibility', 'closedCaptions', params)
+      return Transport.send('platform.accessibility', 'closedCaptions', params)
     },
     voiceGuidance(params) {
-      return getOrSet('accessibility', 'voiceGuidance', params)
+      return Transport.send('platform.accessibility', 'voiceGuidance', params)
     },
-  },
-  get(namespacedKeyOrKeys = []) {
-    return Array.isArray(namespacedKeyOrKeys)
-      ? Promise.all(
-          namespacedKeyOrKeys.map(key => {
-            return getProperty.apply(this, key.split('.'))
-          })
-        ).then(values =>
-          namespacedKeyOrKeys.reduce((result, key, index) => {
-            result[key] = values[index]
-            return result
-          }, {})
-        )
-      : getProperty.apply(this, namespacedKeyOrKeys.split('.'))
-  },
-  set(namespacedKey, value) {
-    return setProperty.apply(this, [...namespacedKey.split('.'), ...value])
-  },
-  has(namespacedKey) {
-    return hasProperty.apply(this, namespacedKey.split('.'))
   },
 }

--- a/src/Transport/index.js
+++ b/src/Transport/index.js
@@ -24,8 +24,8 @@ import { initSettings } from '../Settings'
 // TODO need to spec Firebolt Settings
 initSettings({}, { log: true })
 
+const promises = []
 let transport
-let promises = []
 let id = 0
 let transport_service_name = 'com.comcast.BridgeObject_1'
 let timeout
@@ -50,8 +50,7 @@ const getTransportLayer = () => {
     transport = queue
     // get the default bridge service, and flush the queue
     window.ServiceManager.getServiceForJavaScript(transport_service_name, service => {
-      transport = service
-      queue.flush(service)
+      setTransportLayer(service)
     })
   } else {
     // Check for custom, or fall back to mock

--- a/src/Transport/index.js
+++ b/src/Transport/index.js
@@ -1,0 +1,116 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2021 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { default as mock } from './mock'
+import { default as queue } from './queue'
+import { initSettings } from '../Settings'
+
+// TODO need to spec Firebolt Settings
+initSettings({}, { log: true })
+
+let transport
+let promises = []
+let id = 0
+let transport_service_name = 'com.comcast.BridgeObject_1'
+let timeout
+
+// create global handshake namespace
+if (!window.__firebolt) {
+  window.__firebolt = {}
+}
+
+// Returns an FTL queue. Initializes the default transport layer if available
+const getTransportLayer = () => {
+  let transport
+  if (typeof window.__firebolt.transport_service_name === 'string')
+    transport_service_name = window.__firebolt.transport_service_name
+
+  if (
+    typeof window.ServiceManager !== 'undefined' &&
+    window.ServiceManager &&
+    window.ServiceManager.version
+  ) {
+    // Wire up the queue
+    transport = queue
+    // get the default bridge service, and flush the queue
+    window.ServiceManager.getServiceForJavaScript(transport_service_name, service => {
+      transport = service
+      queue.flush(service)
+    })
+  } else {
+    // Check for custom, or fall back to mock
+    transport = queue
+  }
+  return transport
+}
+
+const setTransportLayer = tl => {
+  if (timeout) clearTimeout(timeout)
+
+  // remove handshake object
+  delete window.__firebolt
+
+  transport = tl
+  queue.flush(tl)
+}
+
+const send = (module, method, params) => {
+  let p = new Promise((resolve, reject) => {
+    promises[id] = {}
+    promises[id].promise = this
+    promises[id].resolve = resolve
+    promises[id].reject = reject
+  })
+
+  let json = { jsonrpc: '2.0', method: module + '.' + method, params: params, id: id }
+  id++
+  transport.send(json)
+
+  return p
+}
+
+transport = getTransportLayer()
+
+// TODO: clean up resolved promises
+transport.receive(json => {
+  let p = promises[json.id]
+
+  if (p) {
+    if (json.error) p.reject(json.error)
+    else {
+      p.resolve(json.result)
+    }
+  }
+})
+
+if (window.__firebolt.getTransportLayer) {
+  setTransportLayer(window.__firebolt.getTransportLayer())
+} else {
+  window.__firebolt.setTransportLayer = setTransportLayer
+}
+
+// in 500ms, default to the mock FTL
+// TODO: design a better way to load mock
+timeout = setTimeout(() => {
+  setTransportLayer(mock)
+}, 500)
+
+export default {
+  send: send,
+}

--- a/src/Transport/mock.js
+++ b/src/Transport/mock.js
@@ -1,0 +1,86 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2021 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// export { default as advertising } from './src/Advertising/defaults'
+// export { default as authentication } from './src/Authentication/defaults'
+// export { default as discovery } from './src/Discovery/defaults'
+// export { default as log } from './src/Log/defaults'
+// export { default as lifecycle } from './src/Lifecycle/defaults'
+// export { default as metrics } from './src/Metrics/defaults'
+import { default as advertising } from '../Advertising/defaults'
+import { default as authentication } from '../Authentication/defaults'
+import { default as discovery, events as discovery_events } from '../Discovery/defaults'
+import { default as lifecycle } from '../Lifecycle/defaults'
+import { default as metrics } from '../Metrics/defaults'
+import { default as platform } from '../Platform/defaults'
+
+import Events, { emit } from '../Events'
+
+let mock = {
+  advertising: advertising,
+  authentication: authentication,
+  discovery: discovery,
+  lifecycle: lifecycle,
+  metrics: metrics,
+  platform: platform,
+}
+
+let events = {
+  discovery: discovery_events,
+}
+
+let callback
+
+function send(json) {
+  setTimeout(() =>
+    callback({ jsonrpc: '2.0', result: getResult(json.method, json.params), id: json.id })
+  )
+}
+
+function receive(_callback) {
+  callback = _callback
+  // set up a test harnesses
+  window['$firebolt_test_harness'] = {
+    emit: function(module, event) {
+      module = module.toLowerCase()
+      if (events[module] && events[module][event]) emit(module, event, events[module][event])
+    },
+  }
+}
+
+function dotGrab(obj = {}, key) {
+  const keys = key.split('.')
+  for (let i = 0; i < keys.length; i++) {
+    obj = obj[keys[i]] = obj[keys[i]] !== undefined ? obj[keys[i]] : {}
+  }
+  return typeof obj === 'object' ? (Object.keys(obj).length ? obj : undefined) : obj
+}
+
+function getResult(method, params) {
+  let api = dotGrab(mock, method)
+
+  if (typeof api === 'function') {
+    return api(params)
+  } else return api
+}
+
+export default {
+  send: send,
+  receive: receive,
+}

--- a/src/Transport/mock.js
+++ b/src/Transport/mock.js
@@ -17,12 +17,6 @@
  * limitations under the License.
  */
 
-// export { default as advertising } from './src/Advertising/defaults'
-// export { default as authentication } from './src/Authentication/defaults'
-// export { default as discovery } from './src/Discovery/defaults'
-// export { default as log } from './src/Log/defaults'
-// export { default as lifecycle } from './src/Lifecycle/defaults'
-// export { default as metrics } from './src/Metrics/defaults'
 import { default as advertising } from '../Advertising/defaults'
 import { default as authentication } from '../Authentication/defaults'
 import { default as discovery, events as discovery_events } from '../Discovery/defaults'
@@ -30,7 +24,7 @@ import { default as lifecycle } from '../Lifecycle/defaults'
 import { default as metrics } from '../Metrics/defaults'
 import { default as platform } from '../Platform/defaults'
 
-import Events, { emit } from '../Events'
+import { emit } from '../Events'
 
 let mock = {
   advertising: advertising,

--- a/src/Transport/queue.js
+++ b/src/Transport/queue.js
@@ -17,22 +17,24 @@
  * limitations under the License.
  */
 
-import Transport from '../Transport'
+let callback
+let queue = []
+
+function send(json) {
+  queue.push(json)
+}
+
+function receive(_callback) {
+  callback = _callback
+}
+
+function flush(transport) {
+  transport.receive(callback)
+  queue.forEach(item => transport.send(item))
+}
 
 export default {
-  config() {
-    return Transport.send('advertising', 'config')
-  },
-  policy() {
-    return Transport.send('advertising', 'policy')
-  },
-  advertisingId() {
-    return Transport.send('advertising', 'advertisingId')
-  },
-  deviceAttributes() {
-    return Transport.send('advertising', 'deviceAttributes')
-  },
-  appStoreId() {
-    return Transport.send('advertising', 'appStoreId')
-  },
+  send: send,
+  receive: receive,
+  flush: flush,
 }


### PR DESCRIPTION
## Overview
Created a Transport Layer API for sending/receiving JSON-RPC from a Firebolt Execution Environment
  
## Justification
The Transport Layer API should be agnostic to the actual Firebolt API, to minimize code duplication / chance of typos / etc.

## Changes
- Added a mock Transport Layer w/ a "defaults.js" in each module
- Created a two-way handshake to wire up SDK to FTL regardless of which loads first
- Created a Queue FTL, to store API requests until the handshake is done
- Created a way to store mock events in each defaults.js, so the mock FTL can dispatch them for testing