### PR TITLE
Added call to refocus after attaching AppInstance to render tree, to …

### DIFF
--- a/src/Application/index.js
+++ b/src/Application/index.js
@@ -99,6 +99,8 @@ export default function(App, appData, platformSettings) {
 
           this.childList.a(AppInstance)
 
+          this._refocus()
+
           Log.info('App version', this.config.version)
           Log.info('SDK version', sdkVersion)
 


### PR DESCRIPTION
…give it instant focus.

Without this fix you need to click always press a key before the App gets it's focus (unless the focus is set in the App.js `_init()`-method for example)