### PR TITLE
Deepmerge breaks "canvas" stage property

### DIFF
--- a/src/Application/index.js
+++ b/src/Application/index.js
@@ -90,6 +90,10 @@ export default function(App, appData, platformSettings) {
   return class Application extends Lightning.Application {
     constructor(options) {
       const config = Deepmerge(defaultOptions, options)
+      // Deepmerge breaks HTMLCanvasElement, so restore the passed in canvas.
+      if(options.stage.canvas) {
+        config.stage.canvas = options.stage.canvas
+      }
       super(config)
       this.config = config
     }


### PR DESCRIPTION
After some debugging I have found the bug in the lightning-sdk:
```js
const config = Deepmerge(defaultOptions, options)
```
Deepmerge converts the HTMLCanvasElement  from options.stage.canvas in to a simple object `{}`
And there is no getContext on this object.
I think deepmerge should omit merging the options.stage.canvas key.
An immediate solution that comes to mind is making a backup of options.stage.canvas and restoring it in to the config object.