### PR TITLE
Fix init colors requesting a file when receiving an object

### DIFF
--- a/src/Colors/index.js
+++ b/src/Colors/index.js
@@ -58,18 +58,18 @@ export const initColors = file => {
   return new Promise((resolve, reject) => {
     if (typeof file === 'object') {
       addColors(file)
-      resolve()
+      return resolve()
     }
     fetch(file)
       .then(response => response.json())
       .then(json => {
         addColors(json)
-        resolve()
+        return resolve()
       })
       .catch(() => {
         const error = 'Colors file ' + file + ' not found'
         Log.error(error)
-        reject(error)
+        return reject(error)
       })
   })
 }


### PR DESCRIPTION
Fix initColors method requesting a file after it has already loaded an object.

The method did not end after executing `resolve`, so it tried to fetch a file named `[object%20Object]` that did not exists.