### PR TITLE
Fix named route property not being accessed properly

### DIFF
--- a/src/Router/model/Route.js
+++ b/src/Router/model/Route.js
@@ -39,6 +39,10 @@ export default class Route {
     return this._cfg.path
   }
 
+  get name() {
+    return this._cfg.name
+  }
+
   get component() {
     return this._cfg.component
   }


### PR DESCRIPTION
This is a fix for the Named Route navigation paradigm as documented here: https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/router/navigation?id=named-routes

The fix adds a `getter method` on the `Route` model for the `name` property. The `getRouteByName` function in the route utils checks for the name property to retrieve the correct route. Since this property wasn't available on the model, it would never find the correct route and never execute any. Reference: https://github.com/rdkcentral/Lightning-SDK/blob/dev/src/Router/utils/route.js#L240