### PR TITLE
Fix Utils base path when Application is deployed to WebOS

### DIFF
--- a/src/Utils/index.js
+++ b/src/Utils/index.js
@@ -45,6 +45,9 @@ export default {
 }
 
 export const ensureUrlWithProtocol = url => {
+  if (/^\/[^\/]/i.test(url) && /^(?:file:)/i.test(window.location.protocol)) {
+    return window.location.protocol + '//' + url
+  }
   if (/^\/\//.test(url)) {
     return window.location.protocol + url
   }


### PR DESCRIPTION
Fixes this [comment](https://github.com/rdkcentral/Lightning-SDK/issues/68#issuecomment-1129276162) in rdkcentral/Lightning-SDK#68.

Tested on WebOS and Tizen.