### PR TITLE
Remove opinionated smooth behavior from VideoTexture

### DIFF
--- a/src/VideoPlayer/VideoTexture.js
+++ b/src/VideoPlayer/VideoTexture.js
@@ -147,27 +147,23 @@ export default class VideoTexture extends Lightning.Component {
 
   position(top, left) {
     this.videoView.patch({
-      smooth: {
-        x: left,
-        y: top,
-      },
+      x: left,
+      y: top,
     })
   }
 
   size(width, height) {
     this.videoView.patch({
-      smooth: {
-        w: width,
-        h: height,
-      },
+      w: width,
+      h: height,
     })
   }
 
   show() {
-    this.videoView.setSmooth('alpha', 1)
+    this.videoView.alpha = 1
   }
 
   hide() {
-    this.videoView.setSmooth('alpha', 0)
+    this.videoView.alpha = 0
   }
 }


### PR DESCRIPTION
Hi team,

As mentioned in #326, the VideoPlayer plugin behaviour is currently inconsistent when running in textureMode vs. non-textureMode. Particularly, the inconsistency lies in the immediate effect of CSS styling vs the delayed and animated effect of the smoothed property updates in textureMode.
Additionally, a developer using the SDK has no control over the animation parameters, which makes the current implementation very opinionated.

I hope you don't find this change too radical, since the objective is to make the behaviour of the VideoPlayer consistent in both textureMode and non-textureMode and provide a more predictable developer experience.

Best regards,
Mauro