### PR TITLE
Wait for canplay event before playing after seek

### DIFF
--- a/src/VideoPlayer/index.js
+++ b/src/VideoPlayer/index.js
@@ -73,7 +73,8 @@ const hooks = {
     state.playing = false
   },
   seeked() {
-    state.playAfterSeek === true && videoPlayerPlugin.play()
+    state.playAfterSeek &&
+      videoEl.addEventListener('canplay', () => videoPlayerPlugin.play(), { once: true })
     state.playAfterSeek = null
   },
   abort() {


### PR DESCRIPTION
PR to address #328

This solution doesn't work in Safari, but the previous code also didn't work there, so nothing lost.
I checked a couple of STBs and confirmed this addresses the issue of not resuming playback after seek.