### PR TITLE
VideoPlayer: capitalize Error event to maintain consistency

### DIFF
--- a/src/VideoPlayer/events.js
+++ b/src/VideoPlayer/events.js
@@ -18,9 +18,12 @@
  */
 
 export default {
+  adstart: 'AdStart',
+  adend: 'AdEnd'
   abort: 'Abort',
   canplay: 'CanPlay',
   canplaythrough: 'CanPlayThrough',
+  clear: 'Clear',
   durationchange: 'DurationChange',
   emptied: 'Emptied',
   encrypted: 'Encrypted',

--- a/src/VideoPlayer/index.js
+++ b/src/VideoPlayer/index.js
@@ -58,7 +58,7 @@ const state = {
   set playingAds(val) {
     if (this._playingAds !== val) {
       this._playingAds = val
-      fireOnConsumer(val === true ? 'AdStart' : 'AdEnd')
+      fireOnConsumer(events[val === true ? 'adstart' : 'adend'])
     }
   },
   skipTime: false,
@@ -248,7 +248,7 @@ const videoPlayerPlugin = {
               this.play()
             })
             .catch(e => {
-              fireOnConsumer('Error', { videoElement: videoEl, event: e })
+              fireOnConsumer(events['error'], { videoElement: videoEl, event: e })
             })
         })
       })
@@ -284,7 +284,7 @@ const videoPlayerPlugin = {
     this.pause()
     if (textureMode === true) videoTexture.stop()
     return unloader(videoEl).then(() => {
-      fireOnConsumer('Clear', { videoElement: videoEl })
+      fireOnConsumer(events['clear'], { videoElement: videoEl })
     })
   },
 
@@ -292,7 +292,7 @@ const videoPlayerPlugin = {
     if (!this.canInteract) return
     if (textureMode === true) videoTexture.start()
     executeAsPromise(videoEl.play, null, videoEl).catch(e => {
-      fireOnConsumer('Error', { videoElement: videoEl, event: e })
+      fireOnConsumer(events['error'], { videoElement: videoEl, event: e })
     })
   },
 

--- a/src/VideoPlayer/index.js
+++ b/src/VideoPlayer/index.js
@@ -248,7 +248,7 @@ const videoPlayerPlugin = {
               this.play()
             })
             .catch(e => {
-              fireOnConsumer('error', { videoElement: videoEl, event: e })
+              fireOnConsumer('Error', { videoElement: videoEl, event: e })
             })
         })
       })
@@ -292,7 +292,7 @@ const videoPlayerPlugin = {
     if (!this.canInteract) return
     if (textureMode === true) videoTexture.start()
     executeAsPromise(videoEl.play, null, videoEl).catch(e => {
-      fireOnConsumer('error', { videoElement: videoEl, event: e })
+      fireOnConsumer('Error', { videoElement: videoEl, event: e })
     })
   },
 


### PR DESCRIPTION
Every event that is fired on the component that is consuming a `VideoPlayer` event is capitalized, resulting in a method named something like `$videoPlayerPlay`.

However, for the Error event, it is not capitalized properly which means that the method would be named something like `$videoPlayererror`.

This PR attempts to address this inconsistency.