### PR TITLE
TypeScript Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@ node_modules
 .idea
 support/lib
 support/polyfills
+
+# Prevent `tsc` generated typescript types from ended up in the repo
+/types
+
+# Type Docs
+/typedocs

--- a/index.d.ts
+++ b/index.d.ts
@@ -94,5 +94,9 @@ export interface PlatformSettings {
      * for more information.
      */
     quality?: number
+    showFps?: boolean;
+    showVersion?: boolean;
+    log?: boolean;
+    path?: string;
   }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+import { RouterPlatformSettings } from './src/Router/index.js';
+
 /*
  * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
@@ -51,8 +53,15 @@ export interface PlatformSettings {
     metrics?: any;
     mediaPlayer?: any;
     ads?: any;
-    router?: any;
-    tv?: any
+    /**
+     * Router settings
+     *
+     * @remarks
+     * See [Router Settings](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/router/settings?id=router-settings)
+     * for more information.
+     */
+    router?: RouterPlatformSettings;
+    tv?: any;
     purchase?: any;
     pin?: any;
   };

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,89 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export const Ads: any; // export { default as Ads } from './src/Ads'
+export { AppData } from './src/Application/index.js';
+export { default as Application } from './src/Application/index.js';
+export const AudioPlayer: any; // export { default as AudioPlayer } from './src/AudioPlayer'
+export const Colors: any; // export { default as Colors } from './src/Colors'
+export { default as Img } from './src/Img/index.js';
+export const Keyboard: any; // export { default as Keyboard } from './src/Keyboard'
+export { default as Launch } from './src/Launch/index.js';
+export { default as Lightning } from './src/Lightning/index.js';
+export const Locale: any; // export { default as Locale } from './src/Locale'
+export const Language: any; // export { default as Language } from './src/Language'
+export const Log: any; // export { default as Log } from './src/Log'
+export const MediaPlayer: any; // export { default as MediaPlayer } from './src/MediaPlayer'
+export const Metrics: any; // export { default as Metrics } from './src/Metrics'
+export const Pin: any; // export { default as Pin } from './src/Pin'
+export const Profile: any; // export { default as Profile } from './src/Profile'
+export const Purchase: any; // export { default as Purchase } from './src/Purchase'
+export const Registry: any; // export { default as Registry } from './src/Registry'
+export { default as Router } from './src/Router/index.js';
+export const Settings: any; // export { default as Settings } from './src/Settings'
+export const Storage: any; // export { default as Storage } from './src/Storage'
+export const TV: any; // export { default as TV } from './src/TV'
+export { default as Utils } from './src/Utils/index.js';
+export const VideoPlayer: any; // export { default as VideoPlayer } from './src/VideoPlayer'
+export const Metadata: any; // export { default as Metadata } from './src/Metadata'
+
+/**
+ * [Platform Settings](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/settings?id=platform-settings)
+ */
+export interface PlatformSettings {
+  plugins?: {
+    profile?: any;
+    metrics?: any;
+    mediaPlayer?: any;
+    ads?: any;
+    router?: any;
+    tv?: any
+    purchase?: any;
+    pin?: any;
+  };
+  /**
+   * The target ECMAScript environment for the App.
+   */
+  esEnv?: 'es5' | 'es6';
+  textureMode?: boolean;
+  /**
+   * Indicates whether or not to initialize the Lightning Inspector
+   *
+   * @remarks
+   * The Lightning Inspector renders out a HTML structure inside the DOM to mimic the canvas.
+   */
+  inspector?: boolean;
+  onClose?: any;
+  image?: {
+    /**
+     * Image plugin quality
+     *
+     * @remarks
+     * Depending on this setting, the images that are returned by the image server will be smaller
+     * than actually displayed on the screen. Lightning stretches the images to fit them within the
+     * desired dimensions.
+     *
+     * The Platform Setting image.quality is a value between 1 and 100, where 1 means low quality and
+     * 100 is the original image quality.
+     *
+     * See [Image plugin](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/image?id=image)
+     * for more information.
+     */
+    quality?: number
+  }
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 export const Ads: any; // export { default as Ads } from './src/Ads'
-export { AppData } from './src/Application/index.js';
+export type { AppData, FontFace } from './src/Application/index.js';
 export { default as Application } from './src/Application/index.js';
 export const AudioPlayer: any; // export { default as AudioPlayer } from './src/AudioPlayer'
 export const Colors: any; // export { default as Colors } from './src/Colors'

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,7 +19,7 @@
 import { FontFaceDefinition } from './src/Application/index.js';
 import { RouterPlatformSettings } from './src/Router/index.js';
 export const Ads: any; // export { default as Ads } from './src/Ads'
-export type { AppData, FontFaceDefinition } from './src/Application/index.js';
+export { AppData, FontFaceDefinition } from './src/Application/index.js';
 export { default as Application } from './src/Application/index.js';
 export const AudioPlayer: any; // export { default as AudioPlayer } from './src/AudioPlayer'
 export const Colors: any; // export { default as Colors } from './src/Colors'

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,3 @@
-import { RouterPlatformSettings } from './src/Router/index.js';
-
 /*
  * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
@@ -18,8 +16,10 @@ import { RouterPlatformSettings } from './src/Router/index.js';
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { FontFaceDefinition } from './src/Application/index.js';
+import { RouterPlatformSettings } from './src/Router/index.js';
 export const Ads: any; // export { default as Ads } from './src/Ads'
-export type { AppData, FontFace } from './src/Application/index.js';
+export type { AppData, FontFaceDefinition } from './src/Application/index.js';
 export { default as Application } from './src/Application/index.js';
 export const AudioPlayer: any; // export { default as AudioPlayer } from './src/AudioPlayer'
 export const Colors: any; // export { default as Colors } from './src/Colors'
@@ -53,14 +53,7 @@ export interface PlatformSettings {
     metrics?: any;
     mediaPlayer?: any;
     ads?: any;
-    /**
-     * Router settings
-     *
-     * @remarks
-     * See [Router Settings](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/router/settings?id=router-settings)
-     * for more information.
-     */
-    router?: RouterPlatformSettings;
+    router?: any;
     tv?: any;
     purchase?: any;
     pin?: any;
@@ -69,15 +62,83 @@ export interface PlatformSettings {
    * The target ECMAScript environment for the App.
    */
   esEnv?: 'es5' | 'es6';
-  textureMode?: boolean;
   /**
-   * Indicates whether or not to initialize the Lightning Inspector
+   * If set to `true`, initializes the Lightning Inspector
    *
    * @remarks
    * The Lightning Inspector renders out a HTML structure inside the DOM to mimic the canvas.
+   *
+   * @defaultValue `false`
    */
   inspector?: boolean;
+
+  /**
+   * If set to `true`, shows a frames-per-second indicator on the top-left corner of the screen
+   *
+   * @defaultValue `false`
+   */
+  showFps?: boolean;
+  /**
+   * Custom font loader
+   *
+   * @param fontsToLoad
+   * @param store Add loaded [FontFace](https://developer.mozilla.org/en-US/docs/Web/API/FontFace) instances to this array
+   */
+  fontLoader?(fontsToLoad: FontFaceDefinition[], store: FontFace[]): void;
+  /**
+   * If set to `true`, shows the active versions of Lightning Core and SDK on the bottom-right corner of the screen
+   *
+   * @defaultValue `false`
+   */
+  showVersion?: boolean;
+
+  /**
+   * If set to `true`, enables console logging in the Log plugin
+   *
+   * @remarks
+   * See [Log](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/log)
+   * for more information.
+   *
+   */
+  log?: boolean;
+
   onClose?: any;
+
+  /**
+   * Indicates whether or not to render video as a texture on the active drawing
+   * canvas. Can also be set by adding a queryparam ?texture.
+   *
+   * @remarks
+   * Used by the [VideoPlayer](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/videoplayer?id=videoplayer)
+   * plugin.
+   *
+   * @defaultValue `false`
+   */
+  textureMode?: boolean;
+
+  /**
+   * Path to the folder where the assets of the App are located. The path
+   * is used by Utils.asset() to look up assets.
+   *
+   * @remarks
+   * See [Utils](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/utils?id=utils)
+   * for more information.
+   */
+  path?: string;
+  /**
+   * Router plugin settings
+   *
+   * @remarks
+   * See [Router Settings](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/router/settings?id=router-settings)
+   * for more information.
+   */
+  router?: RouterPlatformSettings;
+  /**
+   * Image plugin settings
+   *
+   * See [Image plugin](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/image?id=image)
+   * for more information.
+   */
   image?: {
     /**
      * Image plugin quality
@@ -94,9 +155,5 @@ export interface PlatformSettings {
      * for more information.
      */
     quality?: number
-    showFps?: boolean;
-    showVersion?: boolean;
-    log?: boolean;
-    path?: string;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/polyfill": "^7.11.5",
-        "@lightningjs/core": "*",
+        "@lightningjs/core": "^2.7.0",
         "@metrological/sdk": "github:metrological/metrological-sdk",
         "@michieljs/execute-as-promise": "^1.0.0",
         "deepmerge": "^4.2.2",
@@ -33,7 +33,9 @@
         "lint-staged": "^10.4.0",
         "prettier": "^1.19.1",
         "rollup": "^1.32.1",
-        "rollup-plugin-babel": "^4.4.0"
+        "rollup-plugin-babel": "^4.4.0",
+        "tsd": "^0.22.0",
+        "typedoc": "^0.23.9"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1781,16 +1783,89 @@
       "resolved": "https://registry.npmjs.org/@michieljs/execute-as-promise/-/execute-as-promise-1.0.0.tgz",
       "integrity": "sha512-59LA4Ec5XW8gmobE2USA3tGqBBW27K7cQyl2pPMPgfVwp2YA3vQSqBemBpkA2x2oKnxHbMgq9IS1LeWnyJ376w=="
     },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@tsd/typescript": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/@tsd/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-jbtC+RgKZ9Kk65zuRZbKLTACf+tvFW4Rfq0JEMXrlmV3P3yme+Hm+pnb5fJRyt61SjIitcrC810wj7+1tgsEmg==",
+      "dev": true,
+      "bin": {
+        "tsc": "typescript/bin/tsc",
+        "tsserver": "typescript/bin/tsserver"
+      }
+    },
+    "node_modules/@types/eslint": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
+      "integrity": "sha512-VNcvioYDH8/FxaeTKkM4/TiTwt6pBV9E3OfGmvaw8tPl0rrHCJ4Ll15HRT+pMiFAf/MLQvAzC+6RzUMEL9Ceng==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
       "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
       "dev": true
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "dev": true
+    },
+    "node_modules/@types/minimist": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+      "dev": true
+    },
     "node_modules/@types/node": {
       "version": "18.7.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.6.tgz",
       "integrity": "sha512-EdxgKRXgYsNITy5mjjXjVE/CS8YENSdhiagGrLqjG0pvA2owgJ6i4l7wy/PFZGC0B1/H20lWKN7ONVDNYDZm7A==",
+      "dev": true
+    },
+    "node_modules/@types/normalize-package-data": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
+      "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
     },
     "node_modules/@types/parse-json": {
@@ -1901,6 +1976,24 @@
       "dev": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/astral-regex": {
@@ -2055,6 +2148,32 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase-keys": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/caniuse-lite": {
@@ -2257,6 +2376,37 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/decamelize-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "integrity": "sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==",
+      "dev": true,
+      "dependencies": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/decamelize-keys/node_modules/map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -2291,6 +2441,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/doctrine": {
@@ -2437,6 +2599,98 @@
         "eslint": ">=3.14.1"
       }
     },
+    "node_modules/eslint-formatter-pretty": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-4.1.0.tgz",
+      "integrity": "sha512-IsUTtGxF1hrH6lMWiSl1WbGaiP01eT6kzywdY1U+zLc0MP+nwEnUiS9UI8IaOTUhTeQJLlCEWIbXINBH4YJbBQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/eslint": "^7.2.13",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.0",
+        "eslint-rule-docs": "^1.1.5",
+        "log-symbols": "^4.0.0",
+        "plur": "^4.0.0",
+        "string-width": "^4.2.0",
+        "supports-hyperlinks": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-formatter-pretty/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/eslint-formatter-pretty/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/eslint-formatter-pretty/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-formatter-pretty/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/eslint-formatter-pretty/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint-formatter-pretty/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/eslint-plugin-prettier": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz",
@@ -2457,6 +2711,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/eslint-rule-docs": {
+      "version": "1.1.235",
+      "resolved": "https://registry.npmjs.org/eslint-rule-docs/-/eslint-rule-docs-1.1.235.tgz",
+      "integrity": "sha512-+TQ+x4JdTnDoFEXXb3fDvfGOwnyNV7duH8fXWTPD1ieaBmB8omj7Gw/pMBBu4uI2uJCCU8APDaQJzWuXnTsH4A==",
+      "dev": true
     },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
@@ -2765,6 +3025,22 @@
       "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
+    "node_modules/fast-glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2776,6 +3052,15 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "node_modules/fastq": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "dev": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -2960,6 +3245,44 @@
         "node": ">=4"
       }
     },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby/node_modules/ignore": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/hard-rejection": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -3002,6 +3325,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/human-signals": {
@@ -3178,6 +3513,15 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/irregular-plurals": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.3.0.tgz",
+      "integrity": "sha512-MVBLKUTangM3EfRPFROhmWQQKRDsrgI83J8GS3jXy+OwYqiR2/aoWndYQ5416jLE3uaGgLH7ncme3X9y09gZ3g==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -3238,6 +3582,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3341,6 +3694,21 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.1.0.tgz",
+      "integrity": "sha512-DRf0QjnNeCUds3xTjKlQQ3DpJD51GvDjJfnxUVWg6PZTo2otSm+slzNAxU/35hF8/oJIKoG9slq30JYOsF2azg==",
+      "dev": true
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/levn": {
@@ -3706,11 +4074,88 @@
         "node": ">=10"
       }
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
+    "node_modules/map-obj": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.19.tgz",
+      "integrity": "sha512-rgQF/OxOiLcvgUAj1Q1tAf4Bgxn5h5JZTp04Fx4XUkVhs7B+7YA9JEWJhJpoO8eJt8MkZMwqLCNeNqj1bCREZQ==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/meow": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
+      "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimist": "^1.2.0",
+        "camelcase-keys": "^6.2.2",
+        "decamelize": "^1.2.0",
+        "decamelize-keys": "^1.1.0",
+        "hard-rejection": "^2.1.0",
+        "minimist-options": "4.1.0",
+        "normalize-package-data": "^3.0.0",
+        "read-pkg-up": "^7.0.1",
+        "redent": "^3.0.0",
+        "trim-newlines": "^3.0.0",
+        "type-fest": "^0.18.0",
+        "yargs-parser": "^20.2.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow/node_modules/type-fest": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+      "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/micromatch": {
       "version": "4.0.5",
@@ -3734,6 +4179,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3743,6 +4197,20 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimist-options": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+      "dev": true,
+      "dependencies": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0",
+        "kind-of": "^6.0.3"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/ms": {
@@ -3762,6 +4230,36 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
       "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
       "dev": true
+    },
+    "node_modules/normalize-package-data": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^4.0.1",
+        "is-core-module": "^2.5.0",
+        "semver": "^7.3.4",
+        "validate-npm-package-license": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -3905,6 +4403,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4014,6 +4521,21 @@
         "semver-compare": "^1.0.0"
       }
     },
+    "node_modules/plur": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-4.0.0.tgz",
+      "integrity": "sha512-4UGewrYgqDFw9vV6zNV+ADmPAUAfJPKtGvb/VdpQAx25X5f3xXdGdyOEVFwkl8Hl/tl7+xbeHqSEM+D5/TirUg==",
+      "dev": true,
+      "dependencies": {
+        "irregular-plurals": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4075,6 +4597,164 @@
         "node": ">=6"
       }
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "dev": true,
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg/node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true
+    },
+    "node_modules/read-pkg/node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/read-pkg/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/read-pkg/node_modules/type-fest": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -4084,6 +4764,19 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/regenerate": {
@@ -4221,6 +4914,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rfdc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
@@ -4278,6 +4981,29 @@
       "dev": true,
       "dependencies": {
         "estree-walker": "^0.6.1"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/rxjs": {
@@ -4359,6 +5085,17 @@
         "node": ">=4"
       }
     },
+    "node_modules/shiki": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
+      "integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
+      "dev": true,
+      "dependencies": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-oniguruma": "^1.6.1",
+        "vscode-textmate": "5.2.0"
+      }
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -4419,6 +5156,38 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/spdx-correct": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+      "dev": true,
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
+      "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
       "dev": true
     },
     "node_modules/sprintf-js": {
@@ -4485,6 +5254,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -4507,6 +5288,40 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/supports-hyperlinks": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
+      "integrity": "sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-hyperlinks/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-hyperlinks/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -4641,6 +5456,35 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/trim-newlines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tsd": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.22.0.tgz",
+      "integrity": "sha512-NH+tfEDQ0Ze8gH7TorB6IxYybD+M68EYawe45YNVrbQcydNBfdQHP9IiD0QbnqmwNXrv+l9GAiULT68mo4q/xA==",
+      "dev": true,
+      "dependencies": {
+        "@tsd/typescript": "~4.7.4",
+        "eslint-formatter-pretty": "^4.1.0",
+        "globby": "^11.0.1",
+        "meow": "^9.0.0",
+        "path-exists": "^4.0.0",
+        "read-pkg-up": "^7.0.0"
+      },
+      "bin": {
+        "tsd": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
@@ -4669,6 +5513,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typedoc": {
+      "version": "0.23.10",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.10.tgz",
+      "integrity": "sha512-03EUiu/ZuScUBMnY6p0lY+HTH8SwhzvRE3gImoemdPDWXPXlks83UGTx++lyquWeB1MTwm9D9Ca8RIjkK3AFfQ==",
+      "dev": true,
+      "dependencies": {
+        "lunr": "^2.3.9",
+        "marked": "^4.0.18",
+        "minimatch": "^5.1.0",
+        "shiki": "^0.10.1"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 14.14"
+      },
+      "peerDependencies": {
+        "typescript": "4.6.x || 4.7.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -4755,6 +5655,28 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
+      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+      "dev": true
+    },
+    "node_modules/vscode-textmate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
       "dev": true
     },
     "node_modules/whatwg-fetch": {
@@ -4863,6 +5785,15 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/yocto-queue": {
@@ -6109,16 +7040,76 @@
       "resolved": "https://registry.npmjs.org/@michieljs/execute-as-promise/-/execute-as-promise-1.0.0.tgz",
       "integrity": "sha512-59LA4Ec5XW8gmobE2USA3tGqBBW27K7cQyl2pPMPgfVwp2YA3vQSqBemBpkA2x2oKnxHbMgq9IS1LeWnyJ376w=="
     },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      }
+    },
+    "@tsd/typescript": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/@tsd/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-jbtC+RgKZ9Kk65zuRZbKLTACf+tvFW4Rfq0JEMXrlmV3P3yme+Hm+pnb5fJRyt61SjIitcrC810wj7+1tgsEmg==",
+      "dev": true
+    },
+    "@types/eslint": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
+      "integrity": "sha512-VNcvioYDH8/FxaeTKkM4/TiTwt6pBV9E3OfGmvaw8tPl0rrHCJ4Ll15HRT+pMiFAf/MLQvAzC+6RzUMEL9Ceng==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
     "@types/estree": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
       "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
       "dev": true
     },
+    "@types/json-schema": {
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "dev": true
+    },
+    "@types/minimist": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+      "dev": true
+    },
     "@types/node": {
       "version": "18.7.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.6.tgz",
       "integrity": "sha512-EdxgKRXgYsNITy5mjjXjVE/CS8YENSdhiagGrLqjG0pvA2owgJ6i4l7wy/PFZGC0B1/H20lWKN7ONVDNYDZm7A==",
+      "dev": true
+    },
+    "@types/normalize-package-data": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
+      "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
     },
     "@types/parse-json": {
@@ -6200,6 +7191,18 @@
       "requires": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+      "dev": true
     },
     "astral-regex": {
       "version": "2.0.0",
@@ -6310,6 +7313,23 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
+    },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
+    "camelcase-keys": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      }
     },
     "caniuse-lite": {
       "version": "1.0.30001378",
@@ -6462,6 +7482,30 @@
         "ms": "2.1.2"
       }
     },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true
+    },
+    "decamelize-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "integrity": "sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==",
+      "dev": true,
+      "requires": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "dependencies": {
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
+          "dev": true
+        }
+      }
+    },
     "dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -6487,6 +7531,15 @@
       "requires": {
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
+      }
+    },
+    "dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "requires": {
+        "path-type": "^4.0.0"
       }
     },
     "doctrine": {
@@ -6702,6 +7755,73 @@
         "get-stdin": "^6.0.0"
       }
     },
+    "eslint-formatter-pretty": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-4.1.0.tgz",
+      "integrity": "sha512-IsUTtGxF1hrH6lMWiSl1WbGaiP01eT6kzywdY1U+zLc0MP+nwEnUiS9UI8IaOTUhTeQJLlCEWIbXINBH4YJbBQ==",
+      "dev": true,
+      "requires": {
+        "@types/eslint": "^7.2.13",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.0",
+        "eslint-rule-docs": "^1.1.5",
+        "log-symbols": "^4.0.0",
+        "plur": "^4.0.0",
+        "string-width": "^4.2.0",
+        "supports-hyperlinks": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "eslint-plugin-prettier": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz",
@@ -6710,6 +7830,12 @@
       "requires": {
         "prettier-linter-helpers": "^1.0.0"
       }
+    },
+    "eslint-rule-docs": {
+      "version": "1.1.235",
+      "resolved": "https://registry.npmjs.org/eslint-rule-docs/-/eslint-rule-docs-1.1.235.tgz",
+      "integrity": "sha512-+TQ+x4JdTnDoFEXXb3fDvfGOwnyNV7duH8fXWTPD1ieaBmB8omj7Gw/pMBBu4uI2uJCCU8APDaQJzWuXnTsH4A==",
+      "dev": true
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -6834,6 +7960,19 @@
       "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
+    "fast-glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      }
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -6845,6 +7984,15 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "fastq": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.4"
+      }
     },
     "file-entry-cache": {
       "version": "6.0.1",
@@ -6981,6 +8129,34 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
     },
+    "globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "requires": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+          "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+          "dev": true
+        }
+      }
+    },
+    "hard-rejection": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
+      "dev": true
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -7009,6 +8185,15 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
       "dev": true
+    },
+    "hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
     },
     "human-signals": {
       "version": "1.1.1",
@@ -7132,6 +8317,12 @@
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
     },
+    "irregular-plurals": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.3.0.tgz",
+      "integrity": "sha512-MVBLKUTangM3EfRPFROhmWQQKRDsrgI83J8GS3jXy+OwYqiR2/aoWndYQ5416jLE3uaGgLH7ncme3X9y09gZ3g==",
+      "dev": true
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -7177,6 +8368,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==",
+      "dev": true
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
       "dev": true
     },
     "is-regexp": {
@@ -7247,6 +8444,18 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
       "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "dev": true
+    },
+    "jsonc-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.1.0.tgz",
+      "integrity": "sha512-DRf0QjnNeCUds3xTjKlQQ3DpJD51GvDjJfnxUVWg6PZTo2otSm+slzNAxU/35hF8/oJIKoG9slq30JYOsF2azg==",
+      "dev": true
+    },
+    "kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
     "levn": {
@@ -7516,10 +8725,62 @@
         "yallist": "^4.0.0"
       }
     },
+    "lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
+    "map-obj": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+      "dev": true
+    },
+    "marked": {
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.19.tgz",
+      "integrity": "sha512-rgQF/OxOiLcvgUAj1Q1tAf4Bgxn5h5JZTp04Fx4XUkVhs7B+7YA9JEWJhJpoO8eJt8MkZMwqLCNeNqj1bCREZQ==",
+      "dev": true
+    },
+    "meow": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
+      "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
+      "dev": true,
+      "requires": {
+        "@types/minimist": "^1.2.0",
+        "camelcase-keys": "^6.2.2",
+        "decamelize": "^1.2.0",
+        "decamelize-keys": "^1.1.0",
+        "hard-rejection": "^2.1.0",
+        "minimist-options": "4.1.0",
+        "normalize-package-data": "^3.0.0",
+        "read-pkg-up": "^7.0.1",
+        "redent": "^3.0.0",
+        "trim-newlines": "^3.0.0",
+        "type-fest": "^0.18.0",
+        "yargs-parser": "^20.2.3"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.18.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+          "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+          "dev": true
+        }
+      }
+    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true
     },
     "micromatch": {
@@ -7538,12 +8799,29 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
     },
+    "min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true
+    },
     "minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "requires": {
         "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist-options": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0",
+        "kind-of": "^6.0.3"
       }
     },
     "ms": {
@@ -7563,6 +8841,29 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
       "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
       "dev": true
+    },
+    "normalize-package-data": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^4.0.1",
+        "is-core-module": "^2.5.0",
+        "semver": "^7.3.4",
+        "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -7661,6 +8962,12 @@
         "aggregate-error": "^3.0.0"
       }
     },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7740,6 +9047,15 @@
         "semver-compare": "^1.0.0"
       }
     },
+    "plur": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-4.0.0.tgz",
+      "integrity": "sha512-4UGewrYgqDFw9vV6zNV+ADmPAUAfJPKtGvb/VdpQAx25X5f3xXdGdyOEVFwkl8Hl/tl7+xbeHqSEM+D5/TirUg==",
+      "dev": true,
+      "requires": {
+        "irregular-plurals": "^3.2.0"
+      }
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -7783,12 +9099,134 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true
+    },
+    "quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "dev": true
+    },
+    "read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "dev": true,
+      "requires": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "dependencies": {
+        "hosted-git-info": {
+          "version": "2.8.9",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+          "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+          "dev": true
+        },
+        "normalize-package-data": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "resolve": "^1.10.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+          "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+          "dev": true
+        }
+      }
+    },
+    "read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "dev": true,
+      "requires": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
+        }
+      }
+    },
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
       "requires": {
         "resolve": "^1.1.6"
+      }
+    },
+    "redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "requires": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
       }
     },
     "regenerate": {
@@ -7895,6 +9333,12 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
+    },
     "rfdc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
@@ -7938,6 +9382,15 @@
       "dev": true,
       "requires": {
         "estree-walker": "^0.6.1"
+      }
+    },
+    "run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "requires": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "rxjs": {
@@ -7998,6 +9451,17 @@
         "rechoir": "^0.6.2"
       }
     },
+    "shiki": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
+      "integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
+      "dev": true,
+      "requires": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-oniguruma": "^1.6.1",
+        "vscode-textmate": "5.2.0"
+      }
+    },
     "signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -8046,6 +9510,38 @@
           "dev": true
         }
       }
+    },
+    "spdx-correct": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
+      "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
+      "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -8096,6 +9592,15 @@
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "dev": true
     },
+    "strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "requires": {
+        "min-indent": "^1.0.0"
+      }
+    },
     "strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -8109,6 +9614,33 @@
       "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "supports-hyperlinks": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
+      "integrity": "sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "supports-preserve-symlinks-flag": {
@@ -8211,6 +9743,26 @@
         "is-number": "^7.0.0"
       }
     },
+    "trim-newlines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
+      "dev": true
+    },
+    "tsd": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.22.0.tgz",
+      "integrity": "sha512-NH+tfEDQ0Ze8gH7TorB6IxYybD+M68EYawe45YNVrbQcydNBfdQHP9IiD0QbnqmwNXrv+l9GAiULT68mo4q/xA==",
+      "dev": true,
+      "requires": {
+        "@tsd/typescript": "~4.7.4",
+        "eslint-formatter-pretty": "^4.1.0",
+        "globby": "^11.0.1",
+        "meow": "^9.0.0",
+        "path-exists": "^4.0.0",
+        "read-pkg-up": "^7.0.0"
+      }
+    },
     "tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
@@ -8231,6 +9783,45 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
       "dev": true
+    },
+    "typedoc": {
+      "version": "0.23.10",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.10.tgz",
+      "integrity": "sha512-03EUiu/ZuScUBMnY6p0lY+HTH8SwhzvRE3gImoemdPDWXPXlks83UGTx++lyquWeB1MTwm9D9Ca8RIjkK3AFfQ==",
+      "dev": true,
+      "requires": {
+        "lunr": "^2.3.9",
+        "marked": "^4.0.18",
+        "minimatch": "^5.1.0",
+        "shiki": "^0.10.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
+      }
+    },
+    "typescript": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "dev": true,
+      "peer": true
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -8288,6 +9879,28 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "vscode-oniguruma": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
+      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+      "dev": true
+    },
+    "vscode-textmate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
       "dev": true
     },
     "whatwg-fetch": {
@@ -8368,6 +9981,12 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true
+    },
+    "yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true
     },
     "yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@lightningjs/sdk",
   "version": "5.0.1",
   "license": "Apache-2.0",
+  "types": "index.d.ts",
   "scripts": {
     "postinstall": "node ./scripts/postinstall.js",
     "lint": "eslint '**/*.js'",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "postinstall": "node ./scripts/postinstall.js",
     "lint": "eslint '**/*.js'",
-    "release": "npm publish --access public"
+    "release": "npm publish --access public",
+    "typedoc": "typedoc --tsconfig tsconfig.typedoc.json",
+    "tsd": "tsd"
   },
   "lint-staged": {
     "*.js": [
@@ -45,7 +47,9 @@
     "lint-staged": "^10.4.0",
     "prettier": "^1.19.1",
     "rollup": "^1.32.1",
-    "rollup-plugin-babel": "^4.4.0"
+    "rollup-plugin-babel": "^4.4.0",
+    "tsd": "^0.22.0",
+    "typedoc": "^0.23.9"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.11.5",
-    "@lightningjs/core": "*",
+    "@lightningjs/core": "^2.7.0",
     "@metrological/sdk": "github:metrological/metrological-sdk",
     "@michieljs/execute-as-promise": "^1.0.0",
     "deepmerge": "^4.2.2",

--- a/src/Application/index.d.ts
+++ b/src/Application/index.d.ts
@@ -1,0 +1,47 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Lightning, PlatformSettings } from '../../index.js';
+/**
+ * Application's Top-Level Component Instance (after the Root Application class returned
+ * by `Application()` is instantiated)
+ *
+ * @remarks
+ * Not be confused with `ApplicationInstance` from `Launch`.
+ */
+export let AppInstance: Lightning.Application | undefined;
+
+export interface AppData {
+  // Provided empty for consistent convention and to to allow augmentation
+}
+
+/**
+ * Custom App Specific Data
+ */
+export let AppData: AppData | undefined;
+
+/**
+ * @param App Application's Top-Level Component (will live as a child of the Root Application class returned by this)
+ * @param appData Custom App Specific Data
+ * @param platformSettings Platform Settings
+ */
+export default function(
+  App: Lightning.Component.Constructor,
+  appData: AppData | undefined,
+  platformSettings: PlatformSettings
+): typeof Lightning.Application<Lightning.Application.TemplateSpecLoose>;

--- a/src/Application/index.d.ts
+++ b/src/Application/index.d.ts
@@ -43,10 +43,10 @@ export let AppData: AppData | undefined;
  *
  * @example
  * ```ts
- * import { Router, FontFace } from '@lightningjs/sdk';
+ * import { Router, FontFaceDefinition } from '@lightningjs/sdk';
  *
  * export default class App extends Router.App {
- *   static getFonts(): FontFace[] {
+ *   static getFonts(): FontFaceDefinition[] {
  *     return [
  *       {family: 'Light', url: Utils.asset('fonts/Inter-Light.ttf'), descriptors: {}},
  *       {family: 'Regular', url: Utils.asset('fonts/Inter-Regular.ttf'), descriptors: {}},
@@ -58,7 +58,7 @@ export let AppData: AppData | undefined;
  * }
  * ```
  */
-export interface FontFace {
+export interface FontFaceDefinition {
   /**
    * Font family
    */

--- a/src/Application/index.d.ts
+++ b/src/Application/index.d.ts
@@ -36,6 +36,49 @@ export interface AppData {
 export let AppData: AppData | undefined;
 
 /**
+ * Font face
+ *
+ * @remarks
+ * Used for return value of the `getFonts()` static method is called by the SDK from the Application's Top-Level Component.
+ *
+ * @example
+ * ```ts
+ * import { Router, FontFace } from '@lightningjs/sdk';
+ *
+ * export default class App extends Router.App {
+ *   static getFonts(): FontFace[] {
+ *     return [
+ *       {family: 'Light', url: Utils.asset('fonts/Inter-Light.ttf'), descriptors: {}},
+ *       {family: 'Regular', url: Utils.asset('fonts/Inter-Regular.ttf'), descriptors: {}},
+ *       {family: 'Black', url: Utils.asset('fonts/Inter-Black.ttf'), descriptors: {}},
+ *       {family: 'SemiBold', url: Utils.asset('fonts/Inter-SemiBold.ttf'), descriptors: {}},
+ *       {family: 'Bold', url: Utils.asset('fonts/Inter-Bold.ttf'), descriptors: {}}
+ *     ];
+ *   }
+ * }
+ * ```
+ */
+export interface FontFace {
+  /**
+   * Font family
+   */
+  family: string;
+  /**
+   * URL to font
+   */
+  url: string;
+  /**
+   * Font descriptors
+   */
+  descriptors?: FontFaceDescriptors;
+}
+
+/**
+ * Set up Lightning Application
+ *
+ * @remarks
+ * Use {@link Launch} instead to launch a Lightning app.
+ *
  * @param App Application's Top-Level Component (will live as a child of the Root Application class returned by this)
  * @param appData Custom App Specific Data
  * @param platformSettings Platform Settings

--- a/src/Img/ScaledImageTexture.d.ts
+++ b/src/Img/ScaledImageTexture.d.ts
@@ -1,0 +1,39 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Lightning } from '../../index.js';
+
+declare namespace ScaledImageTexture {
+  export interface Options {
+    type: 'exact' | 'landscape' | 'portrait' | 'cover' | 'contain';
+    w?: number;
+    h?: number;
+  }
+
+  export interface Settings extends Lightning.textures.ImageTexture.Settings {
+    type?: typeof ScaledImageTexture;
+    src?: string;
+    options?: Options;
+  }
+}
+
+declare class ScaledImageTexture extends Lightning.textures.ImageTexture {
+  // Intentionally left blank
+}
+
+export default ScaledImageTexture;

--- a/src/Img/index.d.ts
+++ b/src/Img/index.d.ts
@@ -1,0 +1,88 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import ScaledImageTexture from "./ScaledImageTexture.js";
+
+interface PresetOptionsChain {
+  /**
+   * Resizes the image to the exact dimensions, ignoring the ratio.
+   *
+   * @param w
+   * @param h
+   */
+  exact(w: number, h: number): ScaledImageTexture.Settings;
+  /**
+   * Resizes the image by width, maintaining the ratio.
+   *
+   * @param w
+   */
+  landscape(w: number): ScaledImageTexture.Settings;
+  /**
+   * Resizes the image by height, maintaining the ratio.
+   *
+   * @param h
+   */
+  portrait(h: number): ScaledImageTexture.Settings;
+  /**
+   * Resizes the image in such a way that it covers the entire area. Depending on the orientation
+   * (portrait or landscape) of the source image and that of the desired output, it resizes the image
+   * by width or by height.
+   *
+   * @param w
+   * @param h
+   */
+  cover(w: number, h: number): ScaledImageTexture.Settings;
+  /**
+   * Resizes the image in such a way that it is contained within the available area. Depending on the
+   * orientation (portrait or landscape) of the source image and that of the desired output, it resizes
+   * the image by width or by height.
+   *
+   * @param w
+   * @param h
+   */
+  contain(w: number, h: number): ScaledImageTexture.Settings;
+  /**
+   * Generates the image without resizing it (that is, it uses the original dimensions), while still
+   * passing it through the proxy (and taking advantage of caching).
+   */
+  original(): ScaledImageTexture.Settings;
+}
+
+/**
+ * Image plugin
+ *
+ * @remarks
+ * The standard way of displaying images in Lightning is to just specify the src. This is the preferred way
+ * for local assets (such as background, splash screen, logo and icons) of Lightning Apps.
+ *
+ * It is recommended that you optimize the local assets of your App by resizing them to the exact size and
+ * quality in which you will use them. This positively affects the memory usage of your App.
+ *
+ * However, if you don’t have control over the images to be displayed in your App (for example, because they
+ * originate from a remote API), you can use the Image plugin to resize and crop them.
+ *
+ * See [Image](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/image?id=image)
+ * for more information.
+ *
+ * @param imageUrl
+ * @param options
+ */
+declare function Img(imageUrl: string): PresetOptionsChain;
+declare function Img(imageUrl: string, options: ScaledImageTexture.Options): ScaledImageTexture.Settings;
+
+export default Img;

--- a/src/Launch/index.d.ts
+++ b/src/Launch/index.d.ts
@@ -1,0 +1,39 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { AppData, Lightning, PlatformSettings } from "../../index.js";
+
+/**
+ * Application Instance (after `Launch()` is called)
+ */
+export let ApplicationInstance: Lightning.Application | undefined;
+
+/**
+ * Launch a new Lightning app
+ *
+ * @param App Application's Top-Level Component (will live as a child of the Root Application instance returned by this)
+ * @param appSettings Application Settings
+ * @param platformSettings Platform Settings
+ * @param appData Custom App Specific Data
+ */
+export default function (
+  App: Lightning.Component.Constructor,
+  appSettings: Lightning.Application.Options,
+  platformSettings: PlatformSettings,
+  appData?: AppData
+): Lightning.Application<Lightning.Application.TemplateSpecLoose>;

--- a/src/Lightning/index.d.ts
+++ b/src/Lightning/index.d.ts
@@ -1,0 +1,21 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Lightning from '@lightningjs/core';
+export default Lightning;

--- a/src/Router/base.d.ts
+++ b/src/Router/base.d.ts
@@ -1,0 +1,54 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Lightning } from "../../index.js";
+
+declare namespace RoutedApp {
+  export interface TemplateSpec extends Lightning.Component.TemplateSpecStrong {
+    // Provided empty for consistent convention and to to allow augmentation
+  }
+
+  export interface TemplateSpecLoose extends TemplateSpec {
+    [s: string]: any
+  }
+
+  export interface EventMap extends Lightning.Component.EventMap {
+    // Provided empty for consistent convention and to to allow augmentation
+  }
+
+  export interface SignalMap extends Lightning.Component.SignalMap {
+    // Provided empty for consistent convention and to to allow augmentation
+  }
+
+  export interface TypeConfig extends Lightning.Component.TypeConfig {
+    EventMapType: EventMap;
+    SignalMaptype: SignalMap;
+  }
+}
+
+declare class RoutedApp<
+  TemplateSpecType extends RoutedApp.TemplateSpecLoose = RoutedApp.TemplateSpecLoose,
+  TypeConfigType extends RoutedApp.TypeConfig = RoutedApp.TypeConfig
+> extends Lightning.Component<
+  TemplateSpecType,
+  TypeConfigType
+> {
+
+}
+
+export { RoutedApp }

--- a/src/Router/base.d.ts
+++ b/src/Router/base.d.ts
@@ -19,7 +19,7 @@
 import { Lightning } from "../../index.js";
 
 declare namespace RoutedApp {
-  export interface TemplateSpec extends Lightning.Component.TemplateSpecStrong {
+  export interface TemplateSpec extends Lightning.Component.TemplateSpec {
     // Provided empty for consistent convention and to to allow augmentation
     Pages: {},
     Loading: {

--- a/src/Router/base.d.ts
+++ b/src/Router/base.d.ts
@@ -21,6 +21,11 @@ import { Lightning } from "../../index.js";
 declare namespace RoutedApp {
   export interface TemplateSpec extends Lightning.Component.TemplateSpecStrong {
     // Provided empty for consistent convention and to to allow augmentation
+    Pages: {},
+    Loading: {
+      Label: {}
+    },
+    Widgets: {}
   }
 
   export interface TemplateSpecLoose extends TemplateSpec {
@@ -36,6 +41,7 @@ declare namespace RoutedApp {
   }
 
   export interface TypeConfig extends Lightning.Component.TypeConfig {
+    IsPage: false;
     EventMapType: EventMap;
     SignalMaptype: SignalMap;
   }
@@ -48,7 +54,29 @@ declare class RoutedApp<
   TemplateSpecType,
   TypeConfigType
 > {
+  /**
+   * Gets the Pages host element
+   */
+  get pages(): Lightning.Element;
 
+  /**
+   * Gets the Widgets host element
+   */
+  // @ts-ignore
+  get widgets(): Lightning.Element | undefined;
+
+  /**
+   * Implementable method that overrides the default bevhavior for when a user navigates back
+   * while the history stack is empty.
+   *
+   * @remarks
+   * Normally when the user navigates Back while the history stack is empty, the Router closes the app.
+   * If this method is implemented, the Router will not do that and instead it will execute this method.
+   *
+   * See [Router Events - _handleAppClose](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/router/events?id=_handleappclose)
+   * for more information.
+   */
+  _handleAppClose?(): void;
 }
 
 export { RoutedApp }

--- a/src/Router/index.d.ts
+++ b/src/Router/index.d.ts
@@ -16,14 +16,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Lightning, PlatformSettings } from "../../index.js";
+import { Lightning } from "../../index.js";
 import { RoutedApp } from "./base";
-
-/**
- * TODO: Type this
- */
-type Request = any;
-
+import Request from "./model/Request";
 
 export interface RouterPlatformSettings {
   /**
@@ -481,7 +476,7 @@ type LowercaseString<PossibleString> =
     :
       PossibleString;
 
-export let navigateQueue: Map<string, any /*Request*/>;
+export let navigateQueue: Map<string, Request>;
 
 /**
  * Navigate to Page (adding page to history stack)
@@ -743,6 +738,11 @@ declare module '../../index.js' {
   }
 }
 
+interface HistoryEntry {
+  hash: string;
+  state: Router.HistoryState;
+}
+
 declare namespace Router {
   /**
    * Start the Router
@@ -838,11 +838,8 @@ declare namespace Router {
    * @remarks
    * See [Router History](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/router/history?id=router-history)
    * for more information.
-   *
-   * @privateRemarks
-   * TODO: Type the "history object"
    */
-  export function getHistory(): any;
+  export function getHistory(): HistoryEntry[];
 
   /**
    * Replaces the Router's current history stack with a new one
@@ -851,12 +848,9 @@ declare namespace Router {
    * See [Router History](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/router/history?id=router-history)
    * for more information.
    *
-   * @privateRemarks
-   * TODO: Type the "history object"
-   *
    * @param history
    */
-  export function setHistory(history: any[]): void;
+  export function setHistory(history: HistoryEntry[]): void;
 
   /**
    * Returns the history state object of a previous history stack entry
@@ -947,6 +941,7 @@ declare namespace Router {
     PageParams,
     QueryParams,
     PageTransition,
+    HistoryEntry
   }
 
   /**

--- a/src/Router/index.d.ts
+++ b/src/Router/index.d.ts
@@ -1,0 +1,87 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { RoutedApp } from "./base";
+
+export let navigateQueue: Map<string, any /*Request*/>;
+
+export function navigate(url: any, args?: any, store?: any): any;
+
+export function step(level?: number): any;
+
+export function getResumeHash(): any;
+
+export function initRouter(config: any): any;
+
+declare module '../../index.js' {
+  namespace Lightning {
+    interface Component {
+      widgets: { [s in keyof Router.Widgets]: Router.Widgets[s] }
+    }
+  }
+}
+
+declare namespace Router {
+  const step: any;
+  export const startRouter: any;
+  export { navigate };
+  export const resume: any;
+  export {
+    step,
+    step as go
+  }
+  export const back: any;
+  export const activePage: any;
+  export const getActivePage: any;
+  export const getActiveRoute: any;
+  export const getActiveHash: any;
+  export const focusWidget: any;
+  export const getActiveWidget: any;
+  export const restoreFocus: any;
+  export const isNavigating: any;
+  export const getHistory: any;
+  export const setHistory: any;
+  export const getHistoryState: any;
+  export const replaceHistoryState: any;
+  export const getQueryStringParams: any;
+  export const reload: any;
+  export const symbols: any;
+  export {
+    RoutedApp as App
+  }
+  export const focusPage: any;
+  export const root: any;
+  // export const setupRoutes: any;
+  // export const on: any;
+  // export const before: any;
+  // export const after: any;
+  // - Deprecated and non-functional
+
+  //
+  // Types
+  //
+  /**
+   * Widgets
+   */
+  export interface Widgets {
+    [s: string]: unknown
+  }
+
+}
+
+export default Router;

--- a/src/Router/index.d.ts
+++ b/src/Router/index.d.ts
@@ -960,7 +960,7 @@ declare namespace Router {
    * ```ts
    * declare module "@lightingjs/sdk" {
    *   namespace Router {
-   *     interface AppWidgets {
+   *     interface CustomWidgets {
    *       Menu: Menu;
    *       DetailsMenu: Menu;
    *       PeopleMenu: Menu;
@@ -968,33 +968,32 @@ declare namespace Router {
    *   }
    * }
    * ```
-   *
    */
-  export interface AppWidgets {
+  export interface CustomWidgets {
     // This interface is augmentable
   }
 
   /**
    * @hidden
    */
-  type IsAppWidgetsAugmented = {} extends AppWidgets ? false : true;
+  type IsCustomWidgetsAugmented = object extends Required<CustomWidgets> ? false : true;
 
   /**
    * @hidden
    */
-  type __Widgets = IsAppWidgetsAugmented extends true ? AppWidgets : { [s: string]: unknown };
+  type __Widgets = IsCustomWidgetsAugmented extends true ? CustomWidgets : { [s: string]: unknown };
 
   /**
    * Widgets structure
    *
    * @remarks
-   * If {@link AppWidgets} is not augmented, then this will be allowed to be keyed by any string with
+   * If {@link CustomWidgets} is not augmented, then this will be allowed to be keyed by any string with
    * any `unknown` value type.
    *
    * @sealed
    */
   export interface Widgets extends __Widgets {
-    // This interface is sealed. Augment `AppWidgets` if needed.
+    // This interface is sealed. Augment `CustomWidgets` if needed.
   }
 
   /**
@@ -1013,7 +1012,7 @@ declare namespace Router {
    * @sealed
    */
   export interface WidgetContainer extends LowercaseWidgets {
-    // This interface is sealed. Augment `AppWidgets` if needed.
+    // This interface is sealed. Augment `CustomWidgets` if needed.
   }
 
   /**

--- a/src/Router/index.d.ts
+++ b/src/Router/index.d.ts
@@ -16,56 +16,522 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { Lightning } from "../../index.js";
 import { RoutedApp } from "./base";
+
+/**
+ * Router config
+ */
+interface RouteConfig {
+  /**
+   * The root key indicates which route path must be used as entry point of your App if no location hash is
+   * specified in the URL.
+   *
+   * @remarks
+   * The value of root should be a String, or a function that returns a Promise that resolves to a String.
+   * The value must match the path of one of the defined routes.
+   *
+   * See [Router Configuration - root](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/router/configuration?id=root)
+   * for more information.
+   */
+  root: string | (() => Promise<string>);
+  /**
+   * An array of route definition items.
+   *
+   * @remarks
+   * Each item represents a route path that the App should listen to. It specifies which Page component should be displayed
+   * when that route is hit.
+   *
+   * See [Router Configuration - routes](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/router/configuration?id=routes)
+   * for more information.
+   */
+  routes: RouteDefinition[];
+
+  /**
+   * Provides the ability to execute functionality before the Router loads the first page.
+   *
+   * @remarks
+   * For example, this key can be applied to obtain API tokens.
+   *
+   * See [Router Configuration - boot](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/router/configuration?id=boot)
+   * for more information.
+   */
+  boot?: ((qs: QueryParams) => Promise<void>);
+
+  appInstance?: Lightning.Component;
+
+  /**
+   * If you do not want the Router to update the hash on a navigate, set this to `false`.
+   */
+  updateHash?: boolean;
+
+  /**
+   * Global hook that is invoked right after starting a navigate to a route.
+   *
+   * @remarks
+   * Based on the `from` and `to` parameters that are passed by the Router to the hook, you can decide
+   * to continue, stop or redirect the navigate.
+   *
+   * The hook must return a `Promise<boolean>`. If it resolves to `true`, the Router continues the process. If it
+   * resolves to false, the process is aborted.
+   *
+   * See [Router Configuration - beforeEachRoute](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/router/configuration?id=beforeeachroute)
+   * for more information.
+   */
+  beforeEachRoute?: ((from: string, to: string) => Promise<boolean>);
+
+  /**
+   * Global hook that will be called after every succesful `navigate()` request.
+   *
+   * @remarks
+   * The parameter is the resolved request object.
+   *
+   * See [Router Configuration - afterEachRoute](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/router/configuration?id=aftereachroute)
+   * for more information.
+   */
+  afterEachRoute?: ((request: any) => void); // TODO: Type request !!!
+
+  /**
+   * @deprecated
+   * Boot Component is now available as a [special router](https://rdkcentral.github.io/Lightning-SDK/#/plugins/router/configuration?id=special-routes)
+   *
+   * This property will be removed in a future release.
+   */
+  bootComponent?: Lightning.Component;
+}
+
+interface NavigateArgs {
+  /**
+   * If set to `true`, keeps the current page from which you are navigating in the history stack when the
+   * [lazy destroy](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/router/settings?id=lazydestroy)
+   * feature is enabled.
+   *
+   * @remarks
+   * If you are navigating from one page to another while the [lazy destroy](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/router/settings?id=lazydestroy)
+   * feature is configured, the page from which you navigate is removed from the history stack.
+   *
+   * Sometimes, you might want to keep the current page from which you are navigating alive, to go back to it’s original
+   * state when necessary.
+   *
+   * See [Router Navigation - keepAlive](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/router/navigation?id=keepalive)
+   * for more information.
+   */
+  keepAlive?: boolean;
+  /**
+   * If set to `true`, reloads the current page without a hash change.
+   */
+  reload?: boolean;
+
+  [s: string]: unknown; // Anything is allowed because these aren't encoded into a URL
+}
+
+/**
+ * Parameters from hash that end up in _onUrlParams and in other calls
+ */
+interface PageParams extends Record<string, string | undefined> {
+  /**
+   * Query parameters (after the route hash path)
+   */
+  [Router.symbols.queryParams]?: QueryParams;
+  [Router.symbols.store]?: Record<string, unknown>;
+}
+
+/**
+ * Query params
+ */
+interface QueryParams extends Record<string, string | undefined> {
+
+}
+
+/**
+ * Object used for named navigation
+ *
+ * See [Router Navigation - Named Routes](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/router/navigation?id=named-routes)
+ * for more information.
+ */
+interface NamedNavigationPath {
+  /**
+   * Named route to navigate to.
+   *
+   * @remarks
+   * See [Router Navigation - Named Routes](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/router/navigation?id=named-routes)
+   * for more information.
+   */
+  to: string;
+  /**
+   * Route params that are embedded in a route hash
+   *
+   * @remarks
+   * If the named route is defined as `"player/:assetId/:playlistId"` and
+   * the params are:
+   * ```
+   * {
+   *   assetId: 123,
+   *   playlistId: 321
+   * }
+   * ```
+   *
+   * The hash `"#player/123/321"` will be navigated to.
+   */
+  params?: Record<string, string | number | boolean>;
+  /**
+   * Query params that are appended to the end of the hash
+   *
+   * @remarks
+   * If the named route is defined as `"guide"` and
+   * the query is defined as:
+   * ```
+   * {
+   *   filter: "sports",
+   *   sort: "rating"
+   * }
+   * ```
+   *
+   * The hash `"#guide?filter=sports&sort=rating"` will be navigated to.
+   */
+  query?: Record<string, string | number | boolean>;
+}
+
+interface RouteDefinition<Constructor extends Router.PageConstructor = Router.PageConstructor> {
+  /**
+   * Path to associate with route.
+   *
+   * See [Router Configuration - Routes](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/router/configuration?id=routes)
+   * for more information.
+   */
+  path: string;
+
+  /**
+   * Page to associate with route.
+   *
+   * @remarks
+   * Can be a Lightning Component (i.e., a class that extends the Lightning.Component) or a function that returns
+   * a dynamic import.
+   *
+   * See [Router Configuration - Component Property](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/router/configuration?id=component-property)
+   * for more information.
+   */
+  component: Constructor | (() => Promise<{ default: Constructor }>);
+
+  /**
+   * ???
+   *
+   * @param page
+   * @param params
+   */
+  on?(page: InstanceType<Constructor>, params: PageParams): Promise<void>;
+
+  /**
+   * ???
+   *
+   * @param page
+   * @param params
+   */
+  before?(page: InstanceType<Constructor>, params: PageParams): Promise<void>;
+
+  /**
+   * ???
+   *
+   * @param page
+   * @param params
+   */
+  after?(page: InstanceType<Constructor>, params: PageParams): Promise<void>;
+
+  /**
+   * ???
+   */
+  cache?: number;
+
+  /**
+   * ???
+   */
+  widgets?: Array<keyof Router.WidgetContainer>;
+}
+
+/**
+ * Lowercase possible strings
+ */
+type LowercaseString<PossibleString> =
+  [PossibleString] extends [string]
+    ?
+      Lowercase<PossibleString>
+    :
+      PossibleString;
 
 export let navigateQueue: Map<string, any /*Request*/>;
 
-export function navigate(url: any, args?: any, store?: any): any;
+/**
+ * Navigate to Page (adding page to history stack)
+ *
+ * @remarks
+ * See [Router Navigation - Navigate](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/router/navigation?id=navigate)
+ * for more information.
+ *
+ * @param path Page path to navigate to
+ * @param args Additional navigation parameters
+ * @param store If set to `false`, prevents the calling page from being added to the history stack.
+ */
+export function navigate(path: string | NamedNavigationPath, store: boolean): void;
+export function navigate(path: string | NamedNavigationPath, args?: NavigateArgs, store?: boolean): void;
 
-export function step(level?: number): any;
+/**
+ * @deprecated Use {@link Router.go}
+ */
+export function step(level?: number): void;
 
-export function getResumeHash(): any;
+export function getResumeHash(): string;
 
-export function initRouter(config: any): any;
+/**
+ * This can be called from the platform / bootstrapper to override
+ * the default getting and setting of the hash
+ * @param config
+ */
+export function initRouter(config: {
+  getHash?(): string,
+  setHash?(hash: string): void
+}): void;
 
+/**
+ * Augment Lightning to include `widgets` on all components
+ */
 declare module '../../index.js' {
   namespace Lightning {
-    interface Component {
-      widgets: { [s in keyof Router.Widgets]: Router.Widgets[s] }
+    namespace Component {
+      interface TypeConfig {
+        IsPage: boolean;
+      }
+    }
+
+    interface Component<
+      TemplateSpecType,
+      TypeConfig
+    > {
+      /**
+       * Lightning SDK Router Widgets
+       *
+       * @remarks
+       * Note: This structure is only available on Lightning SDK Router Pages.
+       *
+       * To declare a Lightning Component as a Router Page, you must set `IsPage` to `true` in the Component's
+       * `TypeConfig`:
+       *
+       * ```ts
+       * interface MyPageTypeConfig extends Lightning.Component.TypeConfig {
+       *   IsPage: true;
+       * }
+       *
+       * export class MyPage extends Lightning.Component<MyPageTemplateSpec, MyPageTypeConfig> {
+       *   _init() {
+       *     this.widgets.mywidget; // Widgets now accessible!
+       *   }
+       * }
+       * ```
+       *
+       * See [Router Widgets](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/router/widgets?id=handling-focus)
+       * for more information.
+       */
+      widgets: [TypeConfig['IsPage']] extends [true] ? Router.WidgetContainer : undefined;
+
+      /**
+       * Overridable history state push/pop method
+       *
+       * @remarks
+       * See [Router History - historyState](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/router/history?id=historystate)
+       * for more information.
+       *
+       * @param params If `params` are provided, this is a "pop" operation. Otherwise, it's a "push"
+       */
+      historyState?(params?: Router.HistoryState | null): Router.HistoryState | null | undefined
     }
   }
 }
 
 declare namespace Router {
-  const step: any;
-  export const startRouter: any;
+  /**
+   * Start the Router
+   *
+   * @remarks
+   * See [Router Configruation](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/router/configuration)
+   * for more information.
+   *
+   * @param config
+   * @param instance
+   */
+  export function startRouter(config: RouteConfig, instance?: Lightning.Component): void;
+
   export { navigate };
-  export const resume: any;
+
+  /**
+   * Resume Router's page loading process after the BootComponent becomoes visible.
+   *
+   * @remarks
+   * See [Router Configuration - BootPage](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/router/configuration?id=bootpage)
+   * for more information.
+   */
+  export function resume(): void;
+
   export {
+    /**
+     * @deprecated Use {@link Router.go}
+     */
     step,
-    step as go
   }
-  export const back: any;
-  export const activePage: any;
-  export const getActivePage: any;
-  export const getActiveRoute: any;
-  export const getActiveHash: any;
-  export const focusWidget: any;
-  export const getActiveWidget: any;
-  export const restoreFocus: any;
-  export const isNavigating: any;
-  export const getHistory: any;
-  export const setHistory: any;
-  export const getHistoryState: any;
-  export const replaceHistoryState: any;
-  export const getQueryStringParams: any;
-  export const reload: any;
-  export const symbols: any;
+
+  /**
+   * Navigate backwards in the history stack
+   *
+   * @param level Number of steps to navigate back in the history stack. Must be negative!
+   */
+  export function go(level?: number): void;
+
+  /**
+   * Navigate to the last page in the history stack
+   */
+  export function back(): void;
+
+  /**
+   * @deprecated Use {@link getActivePage}
+   */
+  export function activePage(): Lightning.Component | null;
+
+  /**
+   * Returns the reference of the active Page instance
+   */
+  export function getActivePage(): Lightning.Component | null;
+
+  /**
+   * Returns the active route path blueprint
+   */
+  export function getActiveRoute(): string | undefined;
+
+  /**
+   * Returns the active hash
+   */
+  export function getActiveHash(): string | undefined;
+
+  /**
+   * Delegate focus to a widget
+   *
+   * @remarks
+   * See [Router Widgets](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/router/widgets?id=handling-focus)
+   * for more information.
+   *
+   * @param name Name of widget to delegate focus to
+   */
+  export function focusWidget(name: keyof Widgets): void;
+
+  /**
+   * Returns the instance of the widget that has focus.
+   */
+  export function getActiveWidget(): Lightning.Component | null;
+
+  /**
+   * @deprecated Use {@link focusPage}
+   */
+  export function restoreFocus(): void;
+
+  /**
+   * Returns `true` if the Router is busy processing a request.
+   */
+  export function isNavigating(): boolean;
+
+  /**
+   * Returns a copy of the Router’s current history stack
+   *
+   * @remarks
+   * See [Router History](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/router/history?id=router-history)
+   * for more information.
+   *
+   * @privateRemarks
+   * TODO: Type the "history object"
+   */
+  export function getHistory(): any;
+
+  /**
+   * Replaces the Router's current history stack with a new one
+   *
+   * @remarks
+   * See [Router History](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/router/history?id=router-history)
+   * for more information.
+   *
+   * @privateRemarks
+   * TODO: Type the "history object"
+   *
+   * @param history
+   */
+  export function setHistory(history: any[]): void;
+
+  /**
+   * Returns the history state object of a previous history stack entry
+   *
+   * @remarks
+   * See [Router History](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/router/history?id=router-history)
+   * for more information.
+   *
+   * @param hash Hash of history state to return. If not provided, the last history state object on the stack is returned.
+   */
+  export function getHistoryState(hash?: string): HistoryState | null;
+
+  /**
+   * Replaces the history state object of the last entry that was added to history. (if `hash` isn't provided)
+   *
+   * @remarks
+   * If `hash` is provided, instead of the last entry, the state of the history entry matching the hash is replaced.
+   *
+   * See [Router History - replaceHistoryState](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/router/history?id=replacehistorystate)
+   * for more information.
+   *
+   * @param state State object to replace (Default: `null`)
+   * @param hash Optional hash
+   */
+  export function replaceHistoryState(state?: HistoryState | null, hash?: string): void;
+
+  /**
+   * Returns an object with the current query parameters specified
+   *
+   * @remarks
+   * Returns `false` if there are none.
+   */
+  export function getQueryStringParams(hash?: string): QueryParams | false;
+
+  /**
+   * Force reload active hash
+   */
+  export function reload(): void;
+
+  /**
+   * Router symbols
+   */
+  export const symbols: {
+    readonly route: unique symbol;
+    readonly hash: unique symbol;
+    readonly store: unique symbol;
+    readonly fromHistory: unique symbol;
+    readonly expires: unique symbol;
+    readonly resume: unique symbol;
+    readonly backtrack: unique symbol;
+    readonly historyState: unique symbol;
+    readonly queryParams: unique symbol;
+  };
+
   export {
     RoutedApp as App
   }
-  export const focusPage: any;
-  export const root: any;
+
+  /**
+   * Delegate focus to the active Page
+   *
+   * @remarks
+   * See [Router Widgets - Handling Focus](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/router/widgets?id=handling-focus)
+   * for more information.
+   */
+  export function focusPage(): void;
+
+  /**
+   * Navigate to root hash
+   */
+  export function root(): void;
+
   // export const setupRoutes: any;
   // export const on: any;
   // export const before: any;
@@ -75,13 +541,108 @@ declare namespace Router {
   //
   // Types
   //
-  /**
-   * Widgets
-   */
-  export interface Widgets {
-    [s: string]: unknown
+  export {
+    RouteConfig,
+    NavigateArgs,
+    NamedNavigationPath,
+    RouteDefinition,
+    PageParams,
+    QueryParams
   }
 
+  /**
+   * Interface containing a list of widgets and their types.
+   *
+   * @remarks
+   * This interface is augmentable. Your application may add to it in order to
+   * facilitate additional type safety in your code.
+   *
+   * The keys are the PascalCase widget names. The values are the widget Component instance types.
+   *
+   * Augmenting this will give the Router's widget APIs auto-complete and error checking.
+   *
+   * @example
+   * Add the following somewhere in your project
+   * ```ts
+   * declare module "@lightingjs/sdk" {
+   *   namespace Router {
+   *     interface AppWidgets {
+   *       Menu: Menu;
+   *       DetailsMenu: Menu;
+   *       PeopleMenu: Menu;
+   *     }
+   *   }
+   * }
+   * ```
+   *
+   */
+  export interface AppWidgets {
+    // This interface is augmentable
+  }
+
+  /**
+   * @hidden
+   */
+  type IsAppWidgetsAugmented = {} extends AppWidgets ? false : true;
+
+  /**
+   * @hidden
+   */
+  type __Widgets = IsAppWidgetsAugmented extends true ? AppWidgets : { [s: string]: unknown };
+
+  /**
+   * Widgets structure
+   *
+   * @remarks
+   * If {@link AppWidgets} is not augmented, then this will be allowed to be keyed by any string with
+   * any `unknown` value type.
+   *
+   * @sealed
+   */
+  export interface Widgets extends __Widgets {
+    // This interface is sealed. Augment `AppWidgets` if needed.
+  }
+
+  /**
+   * @privateRemarks
+   * Lower-cased key version of Widgets used for the WidgetContainer
+   * @hidden
+   */
+  type LowercaseWidgets = { [Key in keyof Widgets as LowercaseString<Key>]: Widgets[Key] };
+
+  /**
+   * Contains all the defined Widgets
+   *
+   * @remarks
+   * Typically accessed from a Router page at `this.widgets`.
+   *
+   * @sealed
+   */
+  export interface WidgetContainer extends LowercaseWidgets {
+    // This interface is sealed. Augment `AppWidgets` if needed.
+  }
+
+  /**
+   * Page instance
+   */
+  export type PageInstance = Lightning.Component<
+    Lightning.Component.TemplateSpecLoose,
+    Lightning.Component.TypeConfig & { IsPage: true }
+  >;
+
+  /**
+   * Constructor for a Page
+   */
+  export type PageConstructor<T extends PageInstance = PageInstance> = new (...args: any[]) => T;
+
+  /**
+   * History state object
+   *
+   * @sealed
+   */
+  export interface HistoryState extends Record<string, unknown> {
+    // Not to be augmented
+  }
 }
 
 export default Router;

--- a/src/Router/model/Request.d.ts
+++ b/src/Router/model/Request.d.ts
@@ -1,0 +1,108 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Router from "../index.js";
+import Route, { RouteProvider } from "./Route.js";
+
+export default class Request {
+  /**
+   * Constructor
+   *
+   * @param hash
+   * @param navArgs
+   * @param storeCaller
+   */
+  constructor(hash?: string, navArgs?: Router.NavigateArgs, storeCaller?: boolean);
+
+  /**
+   * Cancel the request
+   */
+  cancel(): void;
+
+  /**
+   * Alias of {@link hash}
+   */
+  get url(): string;
+
+  get register(): Map<string, unknown>;
+
+  /**
+   * Hash of the request
+   */
+  get hash(): string;
+  set hash(args: string);
+
+  /**
+   * The route of the request
+   */
+  get route(): Route | undefined;
+  set route(args: Route | undefined);
+
+  /**
+   * The data provider method of the request
+   */
+  get provider(): RouteProvider['request'] | undefined;
+  set provider(args: RouteProvider['request'] | undefined);
+
+  /**
+   * Gets the data provider type of the request
+   */
+  get providerType(): RouteProvider['type'] | undefined;
+
+  /**
+   * Sets the data provider type of the request
+   */
+  set providerType(args: RouteProvider['type'] | undefined);
+
+  /**
+   * Sets the page of the request
+   */
+  set page(args: Router.PageConstructor | undefined);
+
+  /**
+   * Gets the page of the request
+   */
+  get page(): Router.PageConstructor | undefined;
+
+  /**
+   * Flag if the instance is created due to this request
+   *
+   * @param args
+   */
+  set isCreated(args: boolean);
+  get isCreated(): boolean;
+
+  /**
+   * Flag if the instance is shared between previous and current request
+   */
+  get isSharedInstance(): boolean;
+  set isSharedInstance(args: boolean);
+
+  /**
+   * Flag if the request has been cancelled
+   */
+  get isCancelled(): boolean;
+
+  /**
+   * If instance is shared between requests we copy the state object
+   * from instance before the new request overrides state
+   */
+  get copiedHistoryState(): Router.HistoryState | null;
+  set copiedHistoryState(v: Router.HistoryState | null);
+}

--- a/src/Router/model/Route.d.ts
+++ b/src/Router/model/Route.d.ts
@@ -1,0 +1,45 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Router from "..";
+
+export interface RouteProvider {
+  type: 'on' | 'before' | 'after';
+  request(page: Router.PageInstance, params: Router.PageParams): Promise<void>;
+}
+
+export default class Route implements Router.RouteDefinition {
+  constructor(config?: Router.RouteDefinition);
+
+  get path(): Router.RouteDefinition['path'];
+
+  get component(): Router.RouteDefinition['component'];
+
+  get options(): Router.RouteDefinition['options'];
+
+  get widgets(): Router.RouteDefinition['widgets'];
+
+  get cache(): Router.RouteDefinition['cache'];
+
+  get hook(): Router.RouteDefinition['hook'];
+
+  get beforeNavigate(): Router.RouteDefinition['beforeNavigate'];
+
+  get provider(): RouteProvider | undefined;
+}

--- a/src/Utils/index.d.ts
+++ b/src/Utils/index.d.ts
@@ -1,0 +1,61 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export function initUtils(config: any): void;
+
+declare namespace Utils {
+  /**
+   * Generates a full URL to local App assets (such as images), based on the path that is configured
+   * in [Platform Settings](https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/settings?id=platform-settings).
+   *
+   * @param relPath
+   */
+  export function asset(relPath: string): string;
+  /**
+   * Generates a proxy URL. This is useful if you are using remote APIs that do not have CORS
+   * (Cross-Origin Resource Sharing) configured correctly.
+   *
+   * @remarks
+   * During development you must specify a proxyUrl as a Platform Setting in settings.json.
+   * During production, the proxyUrl is automatically set (Metrological platform only).
+   *
+   * @param url
+   * @param options Default: `{}`
+   * @returns
+   */
+  export function proxyUrl(url: string, options?: Record<string, string | number | boolean>): string;
+
+  /**
+   * @param url
+   * @param options Default: `{}`
+   * @param type Default: `"url"`
+   */
+  export function makeQueryString(url: string, options?: Record<string, string | number | boolean>, type?: string): string;
+
+  export {
+    ensureUrlWithProtocol
+  }
+}
+
+export default Utils;
+
+export function ensureUrlWithProtocol(url: string): string;
+
+export function makeFullStaticPath(pathname: string, path: string): string;
+
+export function cleanUpPathName(pathname: string): string;

--- a/test-d/Application/Application.test-d.ts
+++ b/test-d/Application/Application.test-d.ts
@@ -1,0 +1,9 @@
+import { expectAssignable } from 'tsd';
+import { Lightning, Application, PlatformSettings } from '../../index.js';
+
+class App extends Lightning.Component {}
+
+function Application_Tests() {
+  /// Test that its callable and returns the right type
+  expectAssignable<Lightning.Application.Constructor>(Application(App, {}, {} as PlatformSettings));
+}

--- a/test-d/Application/Application.test-d.ts
+++ b/test-d/Application/Application.test-d.ts
@@ -1,3 +1,21 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import { expectAssignable } from 'tsd';
 import { Lightning, Application, PlatformSettings } from '../../index.js';
 

--- a/test-d/Img/Img.test-d.ts
+++ b/test-d/Img/Img.test-d.ts
@@ -1,0 +1,24 @@
+import { expectType } from 'tsd';
+import { Img } from '../../index.js';
+import type ScaledImageTexture from '../../src/Img/ScaledImageTexture';
+
+
+function Img_Tests() {
+  /// Without options
+  Img('http://example.com/image.jpg');
+  expectType<ScaledImageTexture.Settings>(Img('http://example.com/image.jpg').contain(123, 123));
+  expectType<ScaledImageTexture.Settings>(Img('http://example.com/image.jpg').cover(123, 123));
+  expectType<ScaledImageTexture.Settings>(Img('http://example.com/image.jpg').exact(123, 123));
+  expectType<ScaledImageTexture.Settings>(Img('http://example.com/image.jpg').landscape(123));
+  expectType<ScaledImageTexture.Settings>(Img('http://example.com/image.jpg').original());
+  expectType<ScaledImageTexture.Settings>(Img('http://example.com/image.jpg').portrait(123));
+
+  /// With options
+  expectType<ScaledImageTexture.Settings>(
+    Img('http://example.com/image.jpg', {
+      type: 'contain',
+      w: 123,
+      h: 123
+    })
+  );
+}

--- a/test-d/Img/Img.test-d.ts
+++ b/test-d/Img/Img.test-d.ts
@@ -1,3 +1,21 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import { expectType } from 'tsd';
 import { Img } from '../../index.js';
 import type ScaledImageTexture from '../../src/Img/ScaledImageTexture';

--- a/test-d/Launch/Launch.test-d.ts
+++ b/test-d/Launch/Launch.test-d.ts
@@ -1,0 +1,9 @@
+import { expectType } from 'tsd';
+import { Lightning, Launch, PlatformSettings } from '../../index.js';
+
+class App extends Lightning.Component {}
+
+function Launch_Tests() {
+  /// Test that its callable and returns the right type
+  expectType<Lightning.Application>(Launch(App, {} as Lightning.Application.Options, {} as PlatformSettings, {}));
+}

--- a/test-d/Launch/Launch.test-d.ts
+++ b/test-d/Launch/Launch.test-d.ts
@@ -1,3 +1,21 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import { expectType } from 'tsd';
 import { Lightning, Launch, PlatformSettings } from '../../index.js';
 

--- a/test-d/README.md
+++ b/test-d/README.md
@@ -1,0 +1,2 @@
+This folder contains [tsd](https://github.com/SamVerschueren/tsd) tests for the TypeScript
+types included with Lightning

--- a/test-d/Router/Router-augmentations.test-d.ts
+++ b/test-d/Router/Router-augmentations.test-d.ts
@@ -1,0 +1,168 @@
+/**
+ * Tests for the Router Lightning augmentations
+ */
+
+import { expectAssignable, expectNotAssignable, expectType } from "tsd";
+import { Lightning, Router } from "../../index.js";
+
+declare module '../../index.js' {
+  namespace Router {
+    interface AppWidgets {
+      MyClockWidget: Lightning.components.BloomComponent
+      MyMenuWidget: Lightning.components.ListComponent
+    }
+  }
+}
+
+function Component_widgets_Tests() {
+  /// `this.widgets` / `this.params` should be available to Components that set `IsPage` to `true`
+  class MyPage extends Lightning.Component<
+    Lightning.Component.TemplateSpecLoose,
+    { IsPage: true } & Lightning.Component.TypeConfig
+  > {
+    _init() {
+      /// Expect `widgets` to be a WidgetContainer
+      expectType<Router.WidgetContainer>(this.widgets);
+
+      /// Expect the widgets in `widgets` to be of the correct types
+      expectType<Lightning.components.BloomComponent>(this.widgets.myclockwidget);
+      expectType<Lightning.components.ListComponent>(this.widgets.mymenuwidget);
+
+      /// Should error on unknown widgets (including PascalCase forms of known widgets)
+      // @ts-expect-error
+      this.widgets.MyClockWidget
+      // @ts-expect-error
+      this.widgets.unknownwidget;
+
+      /// Expect `params` to be the correct type
+      expectType<Router.PageParams | undefined>(this.params);
+    }
+  }
+  /// `this.widgets` / `this.params` should not be available if `IsPage` is not set to `true`
+  class MyComponent1 extends Lightning.Component<
+    Lightning.Component.TemplateSpecLoose,
+    Lightning.Component.TypeConfig
+  > {
+    _init() {
+      expectType<unknown>(this.widgets);
+      expectType<unknown>(this.params);
+    }
+  }
+  class MyComponent2 extends Lightning.Component<
+    Lightning.Component.TemplateSpecLoose,
+    { IsPage: false } & Lightning.Component.TypeConfig
+  > {
+    _init() {
+      expectType<unknown>(this.widgets);
+      expectType<unknown>(this.params);
+    }
+  }
+}
+
+
+function Component_override_Tests() {
+  interface MyPageTypeConfig extends Lightning.Component.TypeConfig {
+    IsPage: true;
+    HistoryStateType: {
+      param1: boolean;
+      param2: number;
+    }
+  }
+
+  /// Overrides with explicit TypeConfig / HistoryStateType
+  class MyPage extends Lightning.Component<
+    Lightning.Component.TemplateSpecLoose,
+    MyPageTypeConfig
+  > {
+    /// historyState should be overridable
+    override historyState(params: Router.HistoryState<MyPageTypeConfig>): Router.HistoryState<MyPageTypeConfig> {
+      if (params) {
+        /// Expect type of params to now be the same exact type as `HistoryStateType` in the `TypeConfig`
+        expectType<MyPageTypeConfig['HistoryStateType']>(params);
+      } else {
+        /// Expect that `Router.HistoryState` for this Page is assingable
+        expectAssignable<Router.HistoryState<MyPageTypeConfig>>({
+            param1: true,
+            param2: 123
+        });
+
+        /// Both params are required
+        expectNotAssignable<Router.HistoryState<MyPageTypeConfig>>({
+          param1: true
+        });
+
+        /// Adding an unknown param should not be assignable to the History State
+        expectNotAssignable<Router.HistoryState<MyPageTypeConfig>>({
+          param1: true,
+          param2: 123,
+          unknownParam: 'abc'
+        });
+
+        return {
+          param1: false,
+          param2: 321
+        }
+      }
+    }
+
+    /// pageTransition should be overridable
+    override pageTransition(pageIn: Router.PageInstance, pageOut: Router.PageInstance | null): Router.PageTransition | Promise<void> {
+      /// Should be able to assign all of the default transition types to `Router.PageTransition`
+      expectAssignable<Router.PageTransition>('crossFade');
+      expectAssignable<Router.PageTransition>('down');
+      expectAssignable<Router.PageTransition>('fade');
+      expectAssignable<Router.PageTransition>('left');
+      expectAssignable<Router.PageTransition>('right');
+      expectAssignable<Router.PageTransition>('up');
+
+      /// Should not be able to assign an unknown transition string
+      expectNotAssignable<Router.PageTransition>('unknownTransition');
+
+      /// Should be able to return a promise
+      return Promise.resolve();
+    }
+
+    /// Ensure all the event handler are overridable without errors
+    override _onDataProvided(): void {
+      // Nothing to test inside
+    }
+
+    override _onMounted(): void {
+      // Nothing to test inside
+    }
+
+    override _onChanged(): void {
+      // Nothing to test inside
+    }
+
+    override _onUrlParams(params: Router.PageParams): void {
+      // Nothing to test inside
+    }
+
+    override _onActivated(page: Router.PageInstance): void {
+      // Nothing to test inside
+    }
+  }
+
+  /// `historyState` should work default to `Record<string, unknown>` if not specified in TypeConfig
+  class MyPage2 extends Lightning.Component {
+    /// Should be no errors with this override signature
+    override historyState(params: Router.HistoryState): Router.HistoryState {
+      if (params) {
+        /// Expect params, at this point, to be a Record<string, unknown>
+        expectType<Record<string, unknown>>(params);
+      } else {
+        /// Expect anything goes for assigning to default HistoryState
+        expectAssignable<Router.HistoryState>({
+          unknownParam1: false,
+          unknownParam2: 321,
+        });
+
+        return {
+          unknownParam1: true,
+          unknownParam2: 123,
+        };
+      }
+    }
+  }
+}

--- a/test-d/Router/Router-augmentations.test-d.ts
+++ b/test-d/Router/Router-augmentations.test-d.ts
@@ -1,3 +1,21 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Tests for the Router Lightning augmentations
  */

--- a/test-d/Router/Router-augmentations.test-d.ts
+++ b/test-d/Router/Router-augmentations.test-d.ts
@@ -7,7 +7,7 @@ import { Lightning, Router } from "../../index.js";
 
 declare module '../../index.js' {
   namespace Router {
-    interface AppWidgets {
+    interface CustomWidgets {
       MyClockWidget: Lightning.components.BloomComponent
       MyMenuWidget: Lightning.components.ListComponent
     }

--- a/test-d/Router/Router.base.test-d.ts
+++ b/test-d/Router/Router.base.test-d.ts
@@ -1,3 +1,21 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import { Lightning, Router } from '../../index.js'
 import { expectAssignable } from 'tsd';
 

--- a/test-d/Router/Router.base.test-d.ts
+++ b/test-d/Router/Router.base.test-d.ts
@@ -1,0 +1,18 @@
+import { Lightning, Router } from '../../index.js'
+import { expectAssignable } from 'tsd';
+
+function RouterApp_Tests() {
+  class MyApp extends Router.App {
+    _init() {
+      /// Pre-existing child Elements are accessible by ref
+      expectAssignable<Lightning.Element>(this.getByRef('Loading')!.getByRef('Label')!);
+      expectAssignable<Lightning.Element>(this.getByRef('Pages')!)
+      expectAssignable<Lightning.Element>(this.getByRef('Widgets')!);
+    }
+
+    /// _handleAppClose should be overridable
+    override _handleAppClose(): void {
+      // Nothing to test here
+    }
+  }
+}

--- a/test-d/Router/Router.test-d.ts
+++ b/test-d/Router/Router.test-d.ts
@@ -125,7 +125,7 @@ function Router_RouteDefinition_Tests() {
     component: Lightning.components.ListComponent as any
   });
 
-  /// Can assign on
+  /// Can assign `on`
   expectAssignable<Router.RouteDefinition>({
     path: 'myPath/:param1/:param2',
     component: MyPage,
@@ -135,6 +135,44 @@ function Router_RouteDefinition_Tests() {
       expectType<string | undefined>(param1);
       expectType<string | undefined>(param2);
     }
+  });
+
+  /// Can assign `before`
+  expectAssignable<Router.RouteDefinition>({
+    path: 'myPath/:param1/:param2',
+    component: MyPage,
+    async before(page, { param1, param2 }) {
+      expectType<Router.PageInstance>(page);
+      expectAssignable<MyPage>(page);
+      expectType<string | undefined>(param1);
+      expectType<string | undefined>(param2);
+    }
+  });
+
+  /// Can assign `after`
+  expectAssignable<Router.RouteDefinition>({
+    path: 'myPath/:param1/:param2',
+    component: MyPage,
+    async after(page, { param1, param2 }) {
+      expectType<Router.PageInstance>(page);
+      expectAssignable<MyPage>(page);
+      expectType<string | undefined>(param1);
+      expectType<string | undefined>(param2);
+    }
+  });
+
+  /// Can assign `cache`
+  expectAssignable<Router.RouteDefinition>({
+    path: 'myPath/:param1/:param2',
+    component: MyPage,
+    cache: 1000
+  });
+
+  /// Can assign `widgets`
+  expectAssignable<Router.RouteDefinition>({
+    path: 'myPath/:param1/:param2',
+    component: MyPage,
+    widgets: ['anotherwidget', 'myclockwidget', 'mymenuwidget', 'mywidget']
   });
 }
 
@@ -379,6 +417,23 @@ function Router_setHistory_Tests() {
   Router.setHistory();
   // @ts-expect-error
   Router.setHistory([], 'abc');
+}
+
+function Router_HistoryState_Tests() {
+  type HistState = {
+    myParam1: number,
+    myParam2: string
+  };
+  interface CustomTypeConfig extends Lightning.Component.TypeConfig {
+    HistoryStateType: HistState
+  }
+
+  /// Should be typed as `Record<string, unknown> | null | undefined` if no params are passed to it
+  expectType<Record<string, unknown> | null | undefined>({} as Router.HistoryState);
+  /// Should extract the `HistoryStateType` if a TypeConfig is passed
+  expectType<HistState | null | undefined>({} as Router.HistoryState<CustomTypeConfig>);
+  /// Otherwise, it should just pass through any other object type passed in
+  expectType<HistState | null | undefined>({} as Router.HistoryState<HistState>);
 }
 
 function Router_getHistoryState_Tests() {

--- a/test-d/Router/Router.test-d.ts
+++ b/test-d/Router/Router.test-d.ts
@@ -1,5 +1,6 @@
 import { expectType, expectAssignable, expectNotAssignable, expectDeprecated, expectNotDeprecated } from 'tsd';
 import { Router, Lightning } from '../../index.js'
+import Request from '../../src/Router/model/Request.js';
 
 function Router_Config_Tests() {
   /// Basic
@@ -71,7 +72,7 @@ function Router_Config_Tests() {
     routes: [],
     beforeEachRoute: async (from, to) => {
       expectType<string>(from);
-      expectType<string>(to);
+      expectType<Request>(to);
       return true;
     }
   });
@@ -81,7 +82,7 @@ function Router_Config_Tests() {
     root: 'splash',
     routes: [],
     afterEachRoute: (request) => {
-      expectType<any>(request); // TODO: Type `request`
+      expectType<Request>(request);
       return true;
     }
   });
@@ -402,13 +403,13 @@ function Router_isNavigating_Tests() {
 }
 
 function Router_getHistory_Tests() {
-  /// Should return any (right now)
-  expectType<any>(Router.getHistory());
+  /// Should return an array of HistoryEntry[]
+  expectType<Router.HistoryEntry[]>(Router.getHistory());
 }
 
 function Router_setHistory_Tests() {
-  /// Should return void, accepts an array of any (right now)
-  expectType<void>(Router.setHistory([123, {}, 'abc']));
+  /// Should return void, accepts an array of history objects
+  expectType<void>(Router.setHistory([{ hash: '', state: {} }, { hash: '', state: {} }]));
 
   /// Should error if first param is not an array or if less than or more than one param is provided
   // @ts-expect-error
@@ -437,7 +438,7 @@ function Router_HistoryState_Tests() {
 }
 
 function Router_getHistoryState_Tests() {
-  /// Should return any (right now), and accept an optional `hash` string
+  /// Should return HistoryState | null, and accept an optional `hash` string
   expectType<Router.HistoryState | null>(Router.getHistoryState());
   expectType<Router.HistoryState | null>(Router.getHistoryState('abc'));
 

--- a/test-d/Router/Router.test-d.ts
+++ b/test-d/Router/Router.test-d.ts
@@ -1,3 +1,21 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2022 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import { expectType, expectAssignable, expectNotAssignable, expectDeprecated, expectNotDeprecated } from 'tsd';
 import { Router, Lightning } from '../../index.js'
 import Request from '../../src/Router/model/Request.js';

--- a/test-d/Router/Router.test-d.ts
+++ b/test-d/Router/Router.test-d.ts
@@ -1,0 +1,440 @@
+import { expectType, expectAssignable, expectNotAssignable, expectDeprecated, expectNotDeprecated } from 'tsd';
+import { Router, Lightning } from '../../index.js'
+
+function Router_RouteConfig_Tests() {
+  /// Basic
+  expectAssignable<Router.RouteConfig>({
+    root: 'splash',
+    routes: [
+      {
+        path: 'splash',
+        component: {} as Router.PageConstructor
+      },
+      {} as Router.RouteDefinition,
+      {} as Router.RouteDefinition
+    ]
+  });
+
+  /// `root` and `routes` are required!
+  expectNotAssignable<Router.RouteConfig>({
+    root: 'splash',
+  });
+  expectNotAssignable<Router.RouteConfig>({
+    routes: [],
+  });
+
+  /// `root` and `routes` type sanity check
+  expectNotAssignable<Router.RouteConfig>({
+    root: 123, // Must be a string!
+    routes: [
+      {} as Router.RouteDefinition
+    ]
+  });
+
+  expectNotAssignable<Router.RouteConfig>({
+    root: 'abc',
+    routes: [
+      {} // Must be RouteDefinition!
+    ]
+  });
+
+  /// `boot` and `root` as promise returning callbacks
+  expectAssignable<Router.RouteConfig>({
+    root: () => {
+      return Promise.resolve('splash')
+    },
+    boot: (qs) => {
+      /// `qs` infers to param type
+      expectType<Record<string, string | undefined>>(qs);
+      return Promise.resolve();
+    },
+    routes: []
+  });
+
+  /// Supports custom `appInstance` any component
+  expectAssignable<Router.RouteConfig>({
+    root: 'splash',
+    routes: [],
+    appInstance: {} as Lightning.Component
+  });
+
+  /// `updateHash`
+  expectAssignable<Router.RouteConfig>({
+    root: 'splash',
+    routes: [],
+    updateHash: false
+  });
+
+  /// `beforeEachRoute`
+  expectAssignable<Router.RouteConfig>({
+    root: 'splash',
+    routes: [],
+    beforeEachRoute: async (from, to) => {
+      expectType<string>(from);
+      expectType<string>(to);
+      return true;
+    }
+  });
+
+  /// `afterEachRoute`
+  expectAssignable<Router.RouteConfig>({
+    root: 'splash',
+    routes: [],
+    afterEachRoute: (request) => {
+      expectType<any>(request); // TODO: Type `request`
+      return true;
+    }
+  });
+
+  /// `bootComponent` deprecated
+  const routeConfig = {} as Router.RouteConfig;
+  expectDeprecated(routeConfig.bootComponent);
+}
+
+function Router_startRouter_Tests() {
+  const routeConfig = {} as Router.RouteConfig;
+  /// Supports just passing a `config`
+  expectType<void>(Router.startRouter(routeConfig));
+  // @ts-expect-error `config` can't be a number
+  Router.startRouter(123);
+
+  /// Supports passing a `config` and an app `instance`
+  expectType<void>(Router.startRouter(routeConfig, {} as Lightning.Component));
+  // @ts-expect-error `instance` can't be a number
+  Router.startRouter(routeConfig, 123);
+}
+
+function Router_RouteDefinition_Tests() {
+  class MyPage extends Lightning.Component<Lightning.Component.TemplateSpecLoose, { IsPage: true } & Lightning.Component.TypeConfig> {}
+
+  /// Simple RouteDefintions can be assigned
+  expectAssignable<Router.RouteDefinition>({
+    path: 'myPath/:param1/:param2',
+    component: MyPage
+  });
+
+  /// Non-Pages cannot be assigned
+  expectNotAssignable<Router.RouteDefinition>({
+    path: 'myPath/:param1/:param2',
+    component: Lightning.components.ListComponent
+  });
+
+  /// Non-Pages can be assigned with `any`
+  expectAssignable<Router.RouteDefinition>({
+    path: 'myPath/:param1/:param2',
+    component: Lightning.components.ListComponent as any
+  });
+
+  /// Can assign on
+  expectAssignable<Router.RouteDefinition>({
+    path: 'myPath/:param1/:param2',
+    component: MyPage,
+    async on(page, { param1, param2 }) {
+      expectType<Router.PageInstance>(page);
+      expectAssignable<MyPage>(page);
+      expectType<string | undefined>(param1);
+      expectType<string | undefined>(param2);
+    }
+  });
+}
+
+function Router_navigate_Tests() {
+  // Many examples taken from documentation:
+  // https://lightningjs.io/docs/#/lightning-sdk-reference/plugins/router/navigation?id=router-navigation
+
+  const namedNavigatePath: Router.NamedNavigationPath = {} as Router.NamedNavigationPath;
+  const navigateArgs: Router.NavigateArgs = {} as Router.NavigateArgs;
+
+  /// Can do simple navigate by string or named route
+  expectType<void>(
+    Router.navigate('player/1638')
+  );
+  expectType<void>(
+    Router.navigate(namedNavigatePath)
+  );
+  /// Can do navigate with args
+  expectType<void>(
+    Router.navigate('player/1638', navigateArgs)
+  );
+  expectType<void>(
+    Router.navigate(namedNavigatePath, navigateArgs)
+  );
+  /// Can do navigate and set 2nd param to false (to prevent history)
+  expectType<void>(
+    Router.navigate('player/1638', false)
+  );
+  expectType<void>(
+    Router.navigate(namedNavigatePath, false)
+  );
+  /// Can do navigate and set 3rd param to false (to prevent history)
+  expectType<void>(
+    Router.navigate('player/1638', navigateArgs, false)
+  );
+  expectType<void>(
+    Router.navigate(namedNavigatePath, navigateArgs, false)
+  );
+}
+
+function Router_NamedNavigationPath_Tests() {
+  /// `to` is the mimimum property required
+  expectAssignable<Router.NamedNavigationPath>({
+    to: 'player',
+  });
+  expectNotAssignable<Router.NamedNavigationPath>({});
+
+  /// Allow `params` to be specified
+  expectAssignable<Router.NamedNavigationPath>({
+    to: 'player',
+    params: {
+      unknownProp1: 123,
+      unknownProp2: 'abc',
+      unknownProp3: true,
+    }
+  });
+
+  /// As well as `query`
+  expectAssignable<Router.NamedNavigationPath>({
+    to: 'player',
+    params: {
+      unknownProp1: 123,
+      unknownProp2: 'abc',
+      unknownProp3: true,
+    },
+    query: {
+      unknownProp1: 123,
+      unknownProp2: 'abc',
+      unknownProp3: true,
+    }
+  });
+
+  /// `params` must be a Record<string, string | number | boolean> (if defined)
+  expectNotAssignable<Router.NamedNavigationPath>({
+    to: 'player',
+    params: {
+      unknownProp4: {} // Not allowed
+    }
+  });
+  expectType<Record<string, string | number | boolean> | undefined>({} as Router.NamedNavigationPath['params']);
+
+  /// `query` must be a Record<string, string | number | boolean> (if defined)
+  expectNotAssignable<Router.NamedNavigationPath>({
+    to: 'player',
+    query: {
+      unknownProp4: {} // Not allowed
+    }
+  });
+  expectType<Record<string, string | number | boolean> | undefined>({} as Router.NamedNavigationPath['params']);
+}
+
+function Router_NavigateArgs_Tests() {
+  /// NavigateArgs allows keepAlive, reload and anything else.
+  expectAssignable<Router.NavigateArgs>({
+    keepAlive: true,
+    reload: true,
+    unknownProp1: 'abc',
+    unknownProp2: 123,
+    unknownProp3: false,
+    unknownProp4: {}
+  });
+
+  /// NavigateArgs: keepAlive and reload must be booleans
+  expectType<boolean | undefined>({} as Router.NavigateArgs['keepAlive']);
+  expectNotAssignable<Router.NavigateArgs>({
+    keepAlive: 'string',
+  });
+  expectType<boolean | undefined>({} as Router.NavigateArgs['reload']);
+  expectNotAssignable<Router.NavigateArgs>({
+    reload: 'string',
+  });
+}
+
+function Router_resume_Tests() {
+  /// Should return void with no params
+  expectType<void>(Router.resume());
+
+  /// Should error if there are any params
+  // @ts-expect-error
+  Router.resume('abc');
+}
+
+
+function Router_step_Tests() {
+  /// `step` is an alias of `go`
+  expectType<typeof Router.go>(Router.step);
+
+  /// Should be deprecated
+  expectDeprecated(Router.step);
+}
+
+function Router_go_Tests() {
+  /// Works with no parameters
+  expectType<void>(Router.go());
+
+  /// Works with numeric parameters
+  expectType<void>(Router.go(-1));
+  expectType<void>(Router.go(-2));
+  expectType<void>(Router.go(-3));
+
+  /// Should not be deprecated
+  expectNotDeprecated(Router.go);
+}
+
+function Router_back_Tests() {
+  /// back() can be called with no parameters
+  expectType<void>(Router.back());
+}
+
+function Router_activePage_Tests() {
+  /// Returns the correct value but is deprecated
+  expectType<Lightning.Component | null>(Router.activePage());
+
+  /// Should be deprecated
+  expectDeprecated(Router.activePage);
+}
+
+function Router_getActivePage_Tests() {
+  /// Returns the correct value and is not deprecated
+  expectType<Lightning.Component | null>(Router.getActivePage());
+
+  /// Should not be deprecated
+  expectNotDeprecated(Router.getActivePage);
+}
+
+function Router_getActiveRoute_Tests() {
+  /// Returns the correct value and is not deprecated
+  expectType<string | undefined>(Router.getActiveRoute());
+}
+
+function Router_getActiveHash_Tests() {
+  /// Returns the correct value and is not deprecated
+  expectType<string | undefined>(Router.getActiveHash());
+}
+
+declare module '../../index.js' {
+  namespace Router {
+    interface AppWidgets {
+      MyWidget: Lightning.Component
+      AnotherWidget: Lightning.Component
+    }
+  }
+}
+
+function Router_focusWidget_Tests() {
+  /// Works with augmented `AppWidgets`
+  expectType<void>(Router.focusWidget('MyWidget'));
+  expectType<void>(Router.focusWidget('AnotherWidget'));
+
+  /// Unknown widgets error (including lowercase forms of known widgets)
+  // @ts-expect-error
+  Router.focusWidget('mywidget');
+  // @ts-expect-error
+  Router.focusWidget('UnknownWidget');
+}
+
+function Router_getActiveWidget_Tests() {
+  /// Returns the right value
+  expectType<Lightning.Component | null>(Router.getActiveWidget());
+  /// Param sanity check: Should not accept a parameter
+  // @ts-expect-error
+  Router.getActiveWidget(123);
+}
+
+function Router_restoreFocus_Tests() {
+  /// Should be an alias of focusPage
+  expectType<typeof Router['restoreFocus']>(Router.focusPage);
+  /// Should be deprecated
+  expectDeprecated(Router.restoreFocus);
+}
+
+function Router_focusPage_Tests() {
+  /// Should return void and accept no params
+  expectType<void>(Router.focusPage());
+
+  /// Param sanity check: Should not accept a parameter
+  // @ts-expect-error
+  Router.getActiveWidget(123);
+
+  /// Should not be deprecated
+  expectNotDeprecated(Router.focusPage);
+}
+
+function Router_isNavigating_Tests() {
+  /// Works as expected
+  expectType<boolean>(Router.isNavigating());
+}
+
+function Router_getHistory_Tests() {
+  /// Should return any (right now)
+  expectType<any>(Router.getHistory());
+}
+
+function Router_setHistory_Tests() {
+  /// Should return void, accepts an array of any (right now)
+  expectType<void>(Router.setHistory([123, {}, 'abc']));
+
+  /// Should error if first param is not an array or if less than or more than one param is provided
+  // @ts-expect-error
+  Router.setHistory(123);
+  // @ts-expect-error
+  Router.setHistory();
+  // @ts-expect-error
+  Router.setHistory([], 'abc');
+}
+
+function Router_getHistoryState_Tests() {
+  /// Should return any (right now), and accept an optional `hash` string
+  expectType<Router.HistoryState | null>(Router.getHistoryState());
+  expectType<Router.HistoryState | null>(Router.getHistoryState('abc'));
+
+  /// Should error if first param isn't a string of if more than 1 param is provided
+  // @ts-expect-error
+  Router.getHistoryState(123);
+  // @ts-expect-error
+  Router.getHistoryState('abc', 123);
+}
+
+function Router_replaceHistoryState_Tests() {
+  /// Should return void and work with no params, 1 param or 2 params
+  expectType<void>(Router.replaceHistoryState());
+  expectType<void>(Router.replaceHistoryState({} as Router.HistoryState));
+  expectType<void>(Router.replaceHistoryState(null));
+  expectType<void>(Router.replaceHistoryState({} as Router.HistoryState, 'hash'));
+
+  /// Should error if params are of wrong type or more than 2
+  // @ts-expect-error
+  Router.replaceHistoryState(123);
+  // @ts-expect-error
+  Router.replaceHistoryState(null, 123);
+  // @ts-expect-error
+  Router.replaceHistoryState(null, 'hash', 'abc');
+}
+
+function Router_getQueryStringParams_Tests() {
+  /// Should return correct type and work with no params or 1 param
+  expectType<Router.QueryParams | false>(Router.getQueryStringParams());
+  expectType<Router.QueryParams | false>(Router.getQueryStringParams('hash'));
+
+  /// Should error if there are more than 1 param or type of param is incorrect
+  // @ts-expect-error
+  Router.getQueryStringParams(false);
+  // @ts-expect-error
+  Router.getQueryStringParams('hash', false);
+}
+
+function Router_reload_Tests() {
+  /// Should return void with no params
+  expectType<void>(Router.reload());
+
+  /// Should error if there are any params
+  // @ts-expect-error
+  Router.reload('abc');
+}
+
+function Router_root_Tests() {
+  /// Should return void with no params
+  expectType<void>(Router.root());
+
+  /// Should error if there are any params
+  // @ts-expect-error
+  Router.root('abc');
+}

--- a/test-d/Router/Router.test-d.ts
+++ b/test-d/Router/Router.test-d.ts
@@ -1,9 +1,9 @@
 import { expectType, expectAssignable, expectNotAssignable, expectDeprecated, expectNotDeprecated } from 'tsd';
 import { Router, Lightning } from '../../index.js'
 
-function Router_RouteConfig_Tests() {
+function Router_Config_Tests() {
   /// Basic
-  expectAssignable<Router.RouteConfig>({
+  expectAssignable<Router.Config>({
     root: 'splash',
     routes: [
       {
@@ -16,22 +16,22 @@ function Router_RouteConfig_Tests() {
   });
 
   /// `root` and `routes` are required!
-  expectNotAssignable<Router.RouteConfig>({
+  expectNotAssignable<Router.Config>({
     root: 'splash',
   });
-  expectNotAssignable<Router.RouteConfig>({
+  expectNotAssignable<Router.Config>({
     routes: [],
   });
 
   /// `root` and `routes` type sanity check
-  expectNotAssignable<Router.RouteConfig>({
+  expectNotAssignable<Router.Config>({
     root: 123, // Must be a string!
     routes: [
       {} as Router.RouteDefinition
     ]
   });
 
-  expectNotAssignable<Router.RouteConfig>({
+  expectNotAssignable<Router.Config>({
     root: 'abc',
     routes: [
       {} // Must be RouteDefinition!
@@ -39,7 +39,7 @@ function Router_RouteConfig_Tests() {
   });
 
   /// `boot` and `root` as promise returning callbacks
-  expectAssignable<Router.RouteConfig>({
+  expectAssignable<Router.Config>({
     root: () => {
       return Promise.resolve('splash')
     },
@@ -52,21 +52,21 @@ function Router_RouteConfig_Tests() {
   });
 
   /// Supports custom `appInstance` any component
-  expectAssignable<Router.RouteConfig>({
+  expectAssignable<Router.Config>({
     root: 'splash',
     routes: [],
     appInstance: {} as Lightning.Component
   });
 
   /// `updateHash`
-  expectAssignable<Router.RouteConfig>({
+  expectAssignable<Router.Config>({
     root: 'splash',
     routes: [],
     updateHash: false
   });
 
   /// `beforeEachRoute`
-  expectAssignable<Router.RouteConfig>({
+  expectAssignable<Router.Config>({
     root: 'splash',
     routes: [],
     beforeEachRoute: async (from, to) => {
@@ -77,7 +77,7 @@ function Router_RouteConfig_Tests() {
   });
 
   /// `afterEachRoute`
-  expectAssignable<Router.RouteConfig>({
+  expectAssignable<Router.Config>({
     root: 'splash',
     routes: [],
     afterEachRoute: (request) => {
@@ -87,12 +87,12 @@ function Router_RouteConfig_Tests() {
   });
 
   /// `bootComponent` deprecated
-  const routeConfig = {} as Router.RouteConfig;
+  const routeConfig = {} as Router.Config;
   expectDeprecated(routeConfig.bootComponent);
 }
 
 function Router_startRouter_Tests() {
-  const routeConfig = {} as Router.RouteConfig;
+  const routeConfig = {} as Router.Config;
   /// Supports just passing a `config`
   expectType<void>(Router.startRouter(routeConfig));
   // @ts-expect-error `config` can't be a number

--- a/test-d/Router/Router.test-d.ts
+++ b/test-d/Router/Router.test-d.ts
@@ -351,7 +351,7 @@ function Router_getActiveHash_Tests() {
 
 declare module '../../index.js' {
   namespace Router {
-    interface AppWidgets {
+    interface CustomWidgets {
       MyWidget: Lightning.Component
       AnotherWidget: Lightning.Component
     }
@@ -359,7 +359,7 @@ declare module '../../index.js' {
 }
 
 function Router_focusWidget_Tests() {
-  /// Works with augmented `AppWidgets`
+  /// Works with augmented `CustomWidgets`
   expectType<void>(Router.focusWidget('MyWidget'));
   expectType<void>(Router.focusWidget('AnotherWidget'));
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "include": [
+    "**/*.d.ts", "**/*.ts"
+  ],
+  "compilerOptions": {
+    "lib": ["ES2018", "DOM"],
+    "outDir": "types",
+    "sourceMap": true,
+    "module": "Node16",
+    "target": "ES2020",
+    "moduleResolution": "node",
+    "allowJs": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "lib": ["ES2018", "DOM"],
     "outDir": "types",
     "sourceMap": true,
-    "module": "Node16",
+    "module": "CommonJS",
     "target": "ES2020",
     "moduleResolution": "node",
     "allowJs": true,

--- a/tsconfig.typedoc.json
+++ b/tsconfig.typedoc.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["**/*.d.ts"],
+  "exclude": ["types"],
+  "typedocOptions": {
+    "entryPoints": ["index.d.ts"],
+    "out": "typedocs",
+    "entryPointStrategy": "expand",
+    "intentionallyNotExported": [
+
+    ]
+  }
+}


### PR DESCRIPTION
This adds partial TypeScript support and TSDoc to Lightning SDK. The focus areas of these types are as follows
- Router plugin
- Image plugin
- Utils plugin
- Platform settings
- Typing for the Lightning export is available in PR rdkcentral/Lightning#407
- Any untyped areas have been stubbed with `any`

_**No runtime code files (.js / .mjs) are modified or added in this PR**_

### Automated Testing

- See rdkcentral/Lightning#407

### API Docs + Generation

- See rdkcentral/Lightning#407

### Still to-do in this PR

- [x] Wait for release of rdkcentral/Lightning#407 and set the minimum version of the Lightning Core dependecy to that version.

### Still to do in future PRs

- See rdkcentral/Lightning#407