### PR TITLE
Updated as per dependabot to Bump semver-regex from 3.1.3 to 3.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7652,9 +7652,9 @@
       "dev": true
     },
     "semver-regex": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.3.tgz",
-      "integrity": "sha512-Aqi54Mk9uYTjVexLnR67rTyBusmwd04cLkHy9hNvk3+G3nT2Oyg7E0l4XVbOaNwIvQ3hHeYxGcyEy+mKreyBFQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.4.tgz",
+      "integrity": "sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==",
       "dev": true
     },
     "shebang-command": {


### PR DESCRIPTION
This PR addresses https://github.com/rdkcentral/Lightning-SDK/pull/322 
#322