### PR TITLE
ENH: Allow plugins to load local json files

### DIFF
--- a/src/Colors/index.js
+++ b/src/Colors/index.js
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+import fetchJson from '../helpers/fetchJson'
 import Log from '../Log'
 import { mergeColors, calculateAlpha, isObject, isString, argbToHSLA, hslaToARGB } from './utils.js'
 
@@ -60,8 +61,7 @@ export const initColors = file => {
       addColors(file)
       return resolve()
     }
-    fetch(file)
-      .then(response => response.json())
+    fetchJson(file)
       .then(json => {
         addColors(json)
         return resolve()

--- a/src/Language/index.js
+++ b/src/Language/index.js
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+import fetchJson from '../helpers/fetchJson'
 import Log from '../Log'
 import Utils from '../Utils'
 
@@ -27,8 +28,7 @@ let dictionary = null
 
 export const initLanguage = (file, language = null) => {
   return new Promise((resolve, reject) => {
-    fetch(file)
-      .then(response => response.json())
+    fetchJson(file)
       .then(json => {
         setTranslations(json)
         // set language (directly or in a promise)
@@ -102,8 +102,7 @@ const setLanguage = lng => {
       } else if (typeof translationsObj === 'string') {
         const url = Utils.asset(translationsObj)
 
-        fetch(url)
-          .then(response => response.json())
+        fetchJson(url)
           .then(json => {
             // save the translations for this language (to prevent loading twice)
             translations[language] = json

--- a/src/helpers/fetchJson.js
+++ b/src/helpers/fetchJson.js
@@ -1,0 +1,32 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2020 Metrological
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export default (file) => {
+  return new Promise((resolve, reject) => {
+    var xhr = new XMLHttpRequest()
+    xhr.onreadystatechange = function() {
+      if (xhr.readyState == XMLHttpRequest.DONE) {
+        if (xhr.status === 200) resolve(JSON.parse(xhr.responseText))
+        else reject(xhr.statusText)
+      }
+    }
+    xhr.open('GET', file)
+    xhr.send(null)
+  })
+}

--- a/src/startApp.js
+++ b/src/startApp.js
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+import fetchJson from './helpers/fetchJson'
+
 const style = document.createElement('style')
 
 document.head.appendChild(style)
@@ -189,20 +191,6 @@ const removeJS = id => {
   if (scriptEl) {
     scriptEl.remove()
   }
-}
-
-const fetchJson = file => {
-  return new Promise((resolve, reject) => {
-    var xhr = new XMLHttpRequest()
-    xhr.onreadystatechange = function() {
-      if (xhr.readyState == XMLHttpRequest.DONE) {
-        if (xhr.status === 200) resolve(JSON.parse(xhr.responseText))
-        else reject(xhr.statusText)
-      }
-    }
-    xhr.open('GET', file)
-    xhr.send(null)
-  })
 }
 
 const sequence = steps => {


### PR DESCRIPTION
On certain plugins, such as the `Language` plugin, when deployed to devices that use the `file:///` protocol, if we ship our App with a local translation file, it fails on some older platforms when using the `fetch` API polyfill.

For example, on Tizen 3.0 that has the Chromium version 39, it uses the `fetch` API polyfill and fails to load the translations file causing our App to stay on a black screen.
However, on Tizen 5.5 that has the Chromium version 69 and doesn't need to polyfill the `fetch` API, it loads with no issue.

closes #360 