### PR TITLE
fix: fetchJson fails on file protocol

### DIFF
--- a/src/helpers/fetchJson.js
+++ b/src/helpers/fetchJson.js
@@ -22,7 +22,9 @@ export default (file) => {
     var xhr = new XMLHttpRequest()
     xhr.onreadystatechange = function() {
       if (xhr.readyState == XMLHttpRequest.DONE) {
-        if (xhr.status === 200) resolve(JSON.parse(xhr.responseText))
+        // file protocol returns 0
+        // http(s) protocol returns 200
+        if (xhr.status === 0 || xhr.status === 200) resolve(JSON.parse(xhr.responseText))
         else reject(xhr.statusText)
       }
     }


### PR DESCRIPTION
When providing a `file:///` protocol on the `fetchJson` helper, the return status is `0` and not `200`.

This fixes this issue, additionally solving the fetch of local language file for example on devices like WebOS and Tizen.