### PR TITLE
Application: Add missing "default default" for precision

### DIFF
--- a/src/Application/index.js
+++ b/src/Application/index.js
@@ -37,7 +37,7 @@ export let AppInstance
 export let AppData
 
 const defaultOptions = {
-  stage: { w: 1920, h: 1080, clearColor: 0x00000000, canvas2d: false },
+  stage: { w: 1920, h: 1080, precision: 1, clearColor: 0x00000000, canvas2d: false },
   debug: false,
   defaultFontFace: 'RobotoRegular',
   keys: {


### PR DESCRIPTION
This fixes a bug introduced by #368 where it was incorrectly assumed that precision was guaranteed to be set with a default in all cases. But apparently it was only specific cases.