### PR TITLE
Fix localcookies import to pull from ESM file (as it originally did)

### DIFF
--- a/src/Storage/index.js
+++ b/src/Storage/index.js
@@ -18,7 +18,7 @@
  */
 
 import Settings from '../Settings'
-import localCookie from 'localcookies'
+import localCookie from 'localcookies/module/localCookie.js'
 
 let namespace
 let lc


### PR DESCRIPTION
A user in one of our internal channels reported the following error when trying to run their Lightning app compiled with Webpack using the recently released [SDK 5.3](https://github.com/rdkcentral/Lightning-SDK/releases/tag/v5.3.0):

```
index.js:29 Uncaught TypeError: localcookies__WEBPACK_IMPORTED_MODULE_1___default(...) is not a constructor
    at initStorage (index.js:29:1)
    at __WEBPACK_DEFAULT_EXPORT__ (index.js:46:14)
```

I tracked the error back to a change that was made in how the `localcookies` package is imported:
```diff
- import localCookie from 'localCookie/module/localCookie.js'
+ import localCookie from 'localcookies'
```
https://github.com/rdkcentral/Lightning-SDK/commit/f20cabea6c9f3354f9de8ad596c7551e74e7ff7b#diff-e4fbcdc3d9beddf9ad84c435c2c392b99094bf11cdccc3a56e88c4265ba51b15R20-R22

Originally the package was imported under the name "localCookie" with a GitHub URL and the update change it to use its proper NPM package name "localcookies". However, it removed the specific path tha referred to the ESM "module" build of it: "/module/localCookie.js".

Unfortunately Webpack, due to default behavior, pulls the [package.json](https://github.com/WebPlatformForEmbedded/localCookie/blob/9c92b80bfbf89bf562fa2a196c7f1d459b9aa380/package.json#L8) defined "browser" build of it, which only defines a window/global export.

This PR adds back the specific path to fix this issue for our users with Webpack who want to upgrade from 5.2.