### PR TITLE
Add API doc link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -36,4 +36,5 @@ The available Lightning SDK plugins are, in alphabetical order:
 * [VersionLabel](plugins/versionlabel.md)
 * [VideoPlayer](plugins/videoplayer.md)
 * [TypeScript Support](typescript.md)
+* [API Docs](/api/lightning-sdk)
 <!---TOC_end--->


### PR DESCRIPTION
Add a link to the TypeDoc API documentation to the bottom of the Lightning SDK TOC

## To-Do
- [ ] PR michielvandergeest/lightningjs.io#56 must be merged first
