### PR TITLE
Fixed router back track issue

### DIFF
--- a/src/Router/index.js
+++ b/src/Router/index.js
@@ -357,14 +357,8 @@ export const step = (level = 0) => {
   // for now we only support negative numbers
   level = Math.abs(level)
 
-  // we can't step back past the amount
-  // of history entries
-  if (level > history.length) {
-    if (isFunction(app._handleAppClose)) {
-      return app._handleAppClose()
-    }
-    return app.application.closeApp()
-  } else if (history.length) {
+  //Check whether we have any history avaialble or not
+  if (history.length) {
     // for now we only support history back
     const route = history.splice(history.length - level, level)[0]
     // store changed history
@@ -394,6 +388,15 @@ export const step = (level = 0) => {
         }
       }
     }
+  }
+
+  // we can't step back past the amount
+  // of history entries
+  if (level > history.length) {
+    if (isFunction(app._handleAppClose)) {
+      return app._handleAppClose()
+    }
+    return app.application.closeApp()
   }
   return false
 }


### PR DESCRIPTION
Fixed issue related to Router backtrack. Here is the issue

When the router is configured with backtrack as true and the user enters App via a deeplink, clicking on the handle back results in either closing or showing an exit dialog if the app has.

This fix will serve when the user enters the deeplink and user presses the back button:
1. Backtrack: enabled ->  Application recursively removes the last part of the hash until it finds a valid path to navigate. In case there is no valid hash then it should exit the application.
2. Backtrack: disabled -> Application is closed