### PR TITLE
DeepMerge failed to merge instantiated objects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@metrological/sdk": "^1.0.0",
         "@michieljs/execute-as-promise": "^1.0.0",
         "deepmerge": "^4.2.2",
+        "is-plain-object": "^5.0.0",
         "localcookies": "^2.0.0",
         "shelljs": "^0.8.5",
         "url-polyfill": "^1.1.10",
@@ -3592,6 +3593,14 @@
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
       "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8375,6 +8384,11 @@
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
       "dev": true
+    },
+    "is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
     },
     "is-regexp": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@metrological/sdk": "^1.0.0",
     "@michieljs/execute-as-promise": "^1.0.0",
     "deepmerge": "^4.2.2",
+    "is-plain-object": "^5.0.0",
     "localcookies": "^2.0.0",
     "shelljs": "^0.8.5",
     "url-polyfill": "^1.1.10",

--- a/src/Application/index.js
+++ b/src/Application/index.js
@@ -19,6 +19,7 @@
 
 import Accessibility from '../Accessibility'
 import Deepmerge from 'deepmerge'
+import { isPlainObject } from 'is-plain-object'
 import Lightning from '../Lightning'
 import Locale from '../Locale'
 import Metrics from '../Metrics'
@@ -99,11 +100,10 @@ export default function(App, appData, platformSettings) {
 
   return class Application extends Lightning.Application {
     constructor(options) {
-      const config = Deepmerge(defaultOptions, options)
-      // Deepmerge breaks HTMLCanvasElement, so restore the passed in canvas.
-      if (options.stage.canvas) {
-        config.stage.canvas = options.stage.canvas
-      }
+      const config = Deepmerge(defaultOptions, options, {
+        isMergeableObject: isPlainObject
+      })
+
       super(config)
       this.config = config
     }


### PR DESCRIPTION
I have observed that the DeepMerge library fails to correctly merge instantiated objects, which is causing issues with the Stage object context option. The canvas option value is being reassinged after DeepMerge but the context option is not being handled properly.

To resolve this issue, I have introduced a new option called 'isMergeableObject' in the DeepMerge library. This option copies the whole instantiated object, instead of just copying its properties. This allows the proper merging of instantiated objects and resolves both the canvas and context options issues with DeepMerge.