### PR TITLE
Added extra eager cleanup of event listeners and targets to prevent r…

### DIFF
--- a/src/Registry/index.js
+++ b/src/Registry/index.js
@@ -130,6 +130,16 @@ export default {
         handler.toString()
       )
       target.removeEventListener(event, handler)
+      // remove key from event listeners object when no events are registered for that event
+      Object.keys(registry.eventListeners[targetIndex]).forEach(event => {
+        if (registry.eventListeners[targetIndex][event].length === 0) {
+          delete registry.eventListeners[targetIndex][event]
+        }
+      })
+      // remove reference to the target when target has no event listeners registered
+      if (Object.keys(registry.eventListeners[targetIndex]).length === 0) {
+        registry.targets.splice(targetIndex)
+      }
     } else {
       Log.error(
         'Remove eventListener',

--- a/src/Registry/index.js
+++ b/src/Registry/index.js
@@ -139,6 +139,7 @@ export default {
       // remove reference to the target when target has no event listeners registered
       if (Object.keys(registry.eventListeners[targetIndex]).length === 0) {
         registry.targets.splice(targetIndex)
+        registry.eventListeners.splice(targetIndex)
       }
     } else {
       Log.error(


### PR DESCRIPTION
Implemented extra eager cleanup in registry plugin to prevent any possible memory leak / memory retention during app lifetime.

Should fix an issue reported on Discord (https://discord.com/channels/1020300788016353311/1124249672890994689/1124249672890994689):

> If I interpret the code correctly, if any event is added, the target on which the event is listened will be kept indefinitely in the targets array of the registry?
> Does this not lead to memory usage buildup? Say you have video tracks on which you listen for events. Every video will have a different video track. Over time after longer usage of an app, the number of videotracks kept in the targets array could build up.
