### PR TITLE
add installation guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,17 @@ It contains [Lightning](https://github.com/rdkcentral/Lightning) and several use
 - Various helpers
 
 Check out the complete [SDK documentation](https://rdkcentral.github.io/Lightning-SDK/) for more information.
+## Installation
 
+Install with NPM
+```bash
+npm install -g @lightningjs/cli
+```
+
+Install with Yarn
+```bash
+yarn global add @lightningjs/cli
+```
 ## Feedback, bugs, questions and support
 
 In case you find any _bugs_ or have _feature requests_, feel free to open an [issue](https://github.com/rdkcentral/Lightning-SDK/issues/new) on the GitHub repository.


### PR DESCRIPTION
- Add installation guidelines to the README so that potential package users can easily install it by simply copying the command. 
-   Fixes #395 