### PR TITLE
Add condition for c2d upon app close

### DIFF
--- a/src/startApp.js
+++ b/src/startApp.js
@@ -112,7 +112,7 @@ const getSettings = () => {
             if (stage.gl) {
               stage.gl.clearColor(0.0, 0.0, 0.0, 0.0)
               stage.gl.clear(stage.gl.COLOR_BUFFER_BIT)
-            } else {
+            } else if(stage.c2d) {
               stage.c2d.clearRect(0, 0, canvas.width, canvas.height)
             }
           }

--- a/support/startApp.js
+++ b/support/startApp.js
@@ -185,7 +185,7 @@ var getSettings = function getSettings() {
           if (stage.gl) {
             stage.gl.clearColor(0.0, 0.0, 0.0, 0.0);
             stage.gl.clear(stage.gl.COLOR_BUFFER_BIT);
-          } else {
+          } else if(stage.c2d) {
             stage.c2d.clearRect(0, 0, canvas.width, canvas.height);
           }
         } // cleanup


### PR DESCRIPTION
Since Lightning core 2.9.0 containing more GC upon cleanup, closing apps via the close helper in the startapp.js is triggering an issue. Since stage.gl is cleaned, the closing logic tries to clean a 2d canvas which never existed.