### PR TITLE
Release - v5.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.5.2
+
+- Updated Lightning core version to 2.13.0
+
 ## v5.5.1
 
 *14 feb 2024*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v5.5.2
 
+*17 apr 2024*
+
 - Updated Lightning core version to 2.13.0
 
 ## v5.5.1

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v5.5.2
+
+*17 apr 2024*
+
+- Updated Lightning core version to 2.13.0
+
 ## v5.5.1
 
 *14 feb 2024*

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightningjs/sdk",
-  "version": "5.5.1",
+  "version": "5.5.2",
   "license": "Apache-2.0",
   "types": "index.d.ts",
   "scripts": {
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.11.5",
-    "@lightningjs/core": "^2.12.1",
+    "@lightningjs/core": "^2.13.0",
     "@metrological/sdk": "^1.0.2",
     "@michieljs/execute-as-promise": "^1.0.0",
     "deepmerge": "^4.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@lightningjs/sdk",
-  "version": "5.5.1",
+  "version": "5.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lightningjs/sdk",
-      "version": "5.5.1",
+      "version": "5.5.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/polyfill": "^7.11.5",
-        "@lightningjs/core": "^2.12.1",
+        "@lightningjs/core": "^2.13.0",
         "@metrological/sdk": "^1.0.2",
         "@michieljs/execute-as-promise": "^1.0.0",
         "deepmerge": "^4.2.2",
@@ -1764,9 +1764,9 @@
       }
     },
     "node_modules/@lightningjs/core": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/@lightningjs/core/-/core-2.12.1.tgz",
-      "integrity": "sha512-g5Uh3BuE9GK5BsdzSL9CgPQ7c/RZ2OnyJxeSp8NMFBgMTV8MNOk4CT734YeV+whp7yUPU6asnAWJEJlB/fRpYQ=="
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@lightningjs/core/-/core-2.13.1.tgz",
+      "integrity": "sha512-/02LOh5n5Oq1GbwxHjXqde5+gU73T6x0f3MEeaF3aBlViDAzns9fsFymJgmtm/AeC7TVGOdr+Eh9nvL3ACu23A=="
     },
     "node_modules/@metrological/sdk": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightningjs/sdk",
-  "version": "5.5.1",
+  "version": "5.5.2",
   "license": "Apache-2.0",
   "types": "index.d.ts",
   "scripts": {
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.11.5",
-    "@lightningjs/core": "^2.12.1",
+    "@lightningjs/core": "^2.13.0",
     "@metrological/sdk": "^1.0.2",
     "@michieljs/execute-as-promise": "^1.0.0",
     "deepmerge": "^4.2.2",


### PR DESCRIPTION
## Changes

- Updates Lightning core version to `2.13.0` to fix most of type definition errors.

### Todo

- [x] Update `CHANGELOG.md`
- [x] Update `docs/changelog.md`
- [x] Update `package.json` and `package-lock.json`
- [x] Update `docs/package.json`