### PR TITLE
updated Colors type definition

### DIFF
--- a/src/Colors/index.d.ts
+++ b/src/Colors/index.d.ts
@@ -9,8 +9,6 @@ export type ColorTransform = {
   get(): number;
 };
 
-export type Colors = {
-  (colorName: string): ColorTransform;
-} & {
-  [colorName: string]: ColorTransform;
-};
+declare const Color: (colorName: string) => ColorTransform;
+
+export default Color;


### PR DESCRIPTION
fixes the following error:

```
Error: Type 'typeof import("node_modules/@lightningjs/sdk/src/Colors/index")' has no call signatures
```