### PR TITLE
Release - v5.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 *05 June 2024*
 
 - Fixed the issue with `Colors` type definitions
-- Updated the documentation
 
 ## v5.5.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v5.5.4
+
+*05 June 2024*
+
+- Fixed the issue with `Colors` type definitions
+- Updated the documentation
+
 ## v5.5.3
 
 *19 apr 2024*

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,7 +5,6 @@
 *05 June 2024*
 
 - Fixed the issue with `Colors` type definitions
-- Updated the documentation
 
 ## v5.5.3
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v5.5.4
+
+*05 June 2024*
+
+- Fixed the issue with `Colors` type definitions
+- Updated the documentation
+
 ## v5.5.3
 
 *19 apr 2024*

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightningjs/sdk",
-  "version": "5.5.3",
+  "version": "5.5.4",
   "license": "Apache-2.0",
   "types": "index.d.ts",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lightningjs/sdk",
-  "version": "5.5.3",
+  "version": "5.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lightningjs/sdk",
-      "version": "5.5.3",
+      "version": "5.5.4",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightningjs/sdk",
-  "version": "5.5.3",
+  "version": "5.5.4",
   "license": "Apache-2.0",
   "types": "index.d.ts",
   "scripts": {

--- a/src/Colors/index.d.ts
+++ b/src/Colors/index.d.ts
@@ -9,8 +9,6 @@ export type ColorTransform = {
   get(): number;
 };
 
-export type Colors = {
-  (colorName: string): ColorTransform;
-} & {
-  [colorName: string]: ColorTransform;
-};
+declare const Color: (colorName: string) => ColorTransform;
+
+export default Color;


### PR DESCRIPTION
- Fixes the issue with `Colors` type definitions

### Todo

- [x] Update `CHANGELOG.md`
- [x] Update `docs/changelog.md`
- [x] Update `package.json` and `package-lock.json`
- [x] Update `docs/package.json`